### PR TITLE
fix(select-input): handle empty string enum values to prevent Radix UI crash

### DIFF
--- a/src/components/settings/SelectInput.tsx
+++ b/src/components/settings/SelectInput.tsx
@@ -15,6 +15,18 @@ interface SelectInputProps {
   option: EnumOption;
 }
 
+// Radix UI Select.Item forbids empty string values (reserved for "clear selection").
+// Use this sentinel to represent an empty-string config value in the UI.
+const EMPTY_SENTINEL = "__empty__";
+
+function toUiValue(v: string) {
+  return v === "" ? EMPTY_SENTINEL : v;
+}
+
+function fromUiValue(v: string) {
+  return v === EMPTY_SENTINEL ? "" : v;
+}
+
 export function SelectInput({ option }: SelectInputProps) {
   const { getValue, setValue, resetValue } = useConfigStore();
   const value = getValue(option.id) as string;
@@ -33,15 +45,15 @@ export function SelectInput({ option }: SelectInputProps) {
       platform={option.platform}
     >
       <Select
-        value={value ?? option.default}
-        onValueChange={(v) => setValue(option.id, v)}
+        value={toUiValue(value ?? option.default)}
+        onValueChange={(v) => setValue(option.id, fromUiValue(v))}
       >
         <SelectTrigger className="max-w-xs">
           <SelectValue placeholder="Select an option" />
         </SelectTrigger>
         <SelectContent>
           {option.options.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
+            <SelectItem key={opt.value} value={toUiValue(opt.value)}>
               {opt.label}
             </SelectItem>
           ))}


### PR DESCRIPTION
## Summary
Fix a crash issue when select on the **Cursor** item on the settings pannel.

## Root cause
The `cursor-style-blink` option in `src/data/ghostty-options.ts` `~line 851` has an enum entry with value: "". Radix UI's `Select.Item` forbids empty string values (it reserves "" for clearing the selection), so the crash happens as soon as the **Cursor** section renders.

  The fix is in `SelectInput.tsx`: map "" → an internal sentinel like "__empty__" for the Radix value prop, and reverse-map back to "" on change.

## Preview
### Before

https://github.com/user-attachments/assets/dc6864fe-4ca4-4aa3-828f-6a9e849eb070

### After

https://github.com/user-attachments/assets/4308d6b2-5fa8-435c-835d-2a505ac187f5

