### PR TITLE
Harden import/export roundtrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ## Unreleased
 
+_No unreleased changes._
+
+## [0.2.0] - 2026-06-04
+
 ### Added
 
+- Added product versioning with a runtime `SPECTRE_VERSION` constant synced to `package.json`.
+- Added app version display in the UI and exported Ghostty config header.
 - Added GitHub Actions CI for typecheck, lint, tests, and production build.
 - Added preset schema validation tests to catch unknown Ghostty options and type mismatches.
 - Added preset keybind validation coverage.
@@ -27,8 +33,13 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Fixed keybind validation for optional-parameter actions such as `copy_to_clipboard` and `close_tab`.
 - Fixed manual palette editing/export/preview consistency by normalizing palette entries to Ghostty `index=color` syntax.
 - Preserved backwards compatibility for previously persisted positional palette arrays.
+- Hardened config import/export roundtrips for quoted strings with spaces or `=`, repeatable strings, repeatable paths, palettes, keybinds, unknown options, default values, and empty-value resets.
+- Added Ghostty `keybind = clear` validation support.
+- Corrected repeatable path schema coverage for `custom-shader` and `gtk-custom-css`.
+- Preserved Ghostty path optional marker semantics for values such as `?optional.css` and `"?required.css"`.
 
 ### Changed
 
+- Exported config headers now include the Spectre app version.
 - Updated README setup instructions to use Bun.
 - Updated README tech stack versions for Next.js 16, Tailwind CSS 4, and Zustand 5.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,19 +26,20 @@ Track Ghostty compatibility separately from the Spectre app version.
    ```
 
 3. Update `CHANGELOG.md`.
-4. Bump `package.json` version.
-5. Commit the release change:
+4. Bump `package.json` version and `src/lib/version.ts` together.
+5. Run the version sync test (`src/lib/version.test.ts`) as part of the full test suite.
+6. Commit the release change:
 
    ```bash
-   git add package.json CHANGELOG.md
+   git add package.json src/lib/version.ts CHANGELOG.md
    git commit -m "chore: release vX.Y.Z"
    ```
 
-6. Tag and push:
+7. Tag and push:
 
    ```bash
    git tag vX.Y.Z
    git push origin main --tags
    ```
 
-7. Draft a GitHub Release using the changelog notes.
+8. Draft a GitHub Release using the changelog notes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectre-ghostty-config",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A beautiful, modern configuration generator for Ghostty terminal",
   "author": "imrajyavardhan12",
   "license": "MIT",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SPECTRE_VERSION } from "@/lib/version";
 
 export default function HomePage() {
   return (
@@ -185,7 +186,7 @@ export default function HomePage() {
         <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-2 text-sm text-muted-foreground group cursor-default">
             <Ghost className="h-4 w-4 transition-transform duration-150 group-hover:rotate-12" />
-            <span>Spectre</span>
+            <span>Spectre v{SPECTRE_VERSION}</span>
             <span className="opacity-50">·</span>
             <span>MIT License</span>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import {
 import { useConfigStore } from "@/lib/store/config-store";
 import { PresetsDialog } from "@/components/editor/PresetsDialog";
 import { cn } from "@/lib/utils";
+import { SPECTRE_VERSION } from "@/lib/version";
 
 export function Header() {
   // Use selectors to properly subscribe to config changes
@@ -67,6 +68,9 @@ export function Header() {
         <Link href="/" className="flex items-center gap-2 group">
           <Ghost className="h-6 w-6 text-primary transition-transform duration-150 group-hover:rotate-12" />
           <span className="font-medium">Spectre</span>
+          <span className="hidden sm:inline text-xs text-muted-foreground">
+            v{SPECTRE_VERSION}
+          </span>
           <span className="text-sm text-muted-foreground hidden lg:inline">
             Ghostty Config Generator
           </span>

--- a/src/data/ghostty-options.test.ts
+++ b/src/data/ghostty-options.test.ts
@@ -73,6 +73,15 @@ describe('ghostty-options', () => {
       expect(option).toBeDefined();
       expect(option?.type).toBe('enum');
     });
+
+    it('should mark official repeatable path options as repeatable', () => {
+      for (const id of ['config-file', 'custom-shader', 'gtk-custom-css']) {
+        const option = getOptionById(id);
+        expect(option, `${id} should exist`).toBeDefined();
+        expect(option?.type, `${id} should be string-backed in Spectre`).toBe('string');
+        expect('repeatable' in option! && option.repeatable, `${id} should be repeatable`).toBe(true);
+      }
+    });
   });
 
   describe('getOptionsByCategory', () => {

--- a/src/data/ghostty-options.ts
+++ b/src/data/ghostty-options.ts
@@ -1854,11 +1854,12 @@ const linuxOptions: ConfigOption[] = [
   {
     id: "gtk-custom-css",
     name: "Custom CSS",
-    description: "Path to custom GTK CSS file.",
+    description: "Path to custom GTK CSS file. Can be repeated to load multiple files.",
     type: "string",
     default: "",
     category: "linux",
     platform: ["linux"],
+    repeatable: true,
     sinceVersion: "1.1.0",
   },
   {
@@ -1955,10 +1956,11 @@ const advancedOptions: ConfigOption[] = [
   {
     id: "custom-shader",
     name: "Custom Shader",
-    description: "Path to custom GLSL shader file (Shadertoy compatible).",
+    description: "Path to custom GLSL shader file (Shadertoy compatible). Can be repeated to load multiple shaders in order.",
     type: "string",
     default: "",
     category: "advanced",
+    repeatable: true,
   },
   {
     id: "custom-shader-animation",

--- a/src/lib/store/config-store.test.ts
+++ b/src/lib/store/config-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useConfigStore } from '@/lib/store/config-store';
+import { SPECTRE_VERSION } from '@/lib/version';
 import { act } from '@testing-library/react';
 
 // Helper to run hooks inside a test
@@ -164,6 +165,8 @@ cursor-style-blink = true
       const configString = `
 keybind = ctrl+shift+c=copy_to_clipboard
 keybind = ctrl+shift+v=paste_from_clipboard
+keybind = ctrl+shift+e=text:FOO=bar
+keybind = clear
 `;
 
       act(() => {
@@ -174,13 +177,143 @@ keybind = ctrl+shift+v=paste_from_clipboard
       expect(state.config['keybind']).toEqual([
         'ctrl+shift+c=copy_to_clipboard',
         'ctrl+shift+v=paste_from_clipboard',
+        'ctrl+shift+e=text:FOO=bar',
+        'clear',
       ]);
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).toContain('keybind = ctrl+shift+e=text:FOO=bar');
+      expect(output).toContain('keybind = clear');
+    });
+
+    it('should round-trip quoted strings with spaces and equals signs', () => {
+      const configString = `
+title = "Spectre = Ghostty Config"
+command = "zsh -lc echo=hello"
+unknown-option = "raw = value with spaces"
+`;
+
+      act(() => {
+        useConfigStore.getState().importConfig(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config['title']).toBe('Spectre = Ghostty Config');
+      expect(state.config['command']).toBe('zsh -lc echo=hello');
+      expect(state.config['unknown-option']).toBe('raw = value with spaces');
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).toContain('title = "Spectre = Ghostty Config"');
+      expect(output).toContain('command = "zsh -lc echo=hello"');
+      expect(output).toContain('unknown-option = "raw = value with spaces"');
+    });
+
+    it('should round-trip repeatable string options', () => {
+      const configString = `
+font-family = JetBrains Mono
+font-family = Symbols Nerd Font
+env = PATH=/usr/local/bin
+env = EDITOR=nvim
+config-file = ?local
+config-file = /etc/ghostty/config
+custom-shader = shaders/crt.glsl
+custom-shader = shaders/glow.glsl
+gtk-custom-css = gtk/base.css
+gtk-custom-css = gtk/overrides.css
+`;
+
+      act(() => {
+        useConfigStore.getState().importConfig(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config['font-family']).toEqual([
+        'JetBrains Mono',
+        'Symbols Nerd Font',
+      ]);
+      expect(state.config['env']).toEqual([
+        'PATH=/usr/local/bin',
+        'EDITOR=nvim',
+      ]);
+      expect(state.config['config-file']).toEqual([
+        '?local',
+        '/etc/ghostty/config',
+      ]);
+      expect(state.config['custom-shader']).toEqual([
+        'shaders/crt.glsl',
+        'shaders/glow.glsl',
+      ]);
+      expect(state.config['gtk-custom-css']).toEqual([
+        'gtk/base.css',
+        'gtk/overrides.css',
+      ]);
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).toContain('font-family = "JetBrains Mono"');
+      expect(output).toContain('font-family = "Symbols Nerd Font"');
+      expect(output).toContain('env = PATH=/usr/local/bin');
+      expect(output).toContain('env = EDITOR=nvim');
+      expect(output).toContain('config-file = ?local');
+      expect(output).toContain('config-file = /etc/ghostty/config');
+      expect(output).toContain('custom-shader = shaders/crt.glsl');
+      expect(output).toContain('custom-shader = shaders/glow.glsl');
+      expect(output).toContain('gtk-custom-css = gtk/base.css');
+      expect(output).toContain('gtk-custom-css = gtk/overrides.css');
+    });
+
+    it('should preserve Ghostty path optional marker semantics', () => {
+      const configString = `
+config-file = first
+config-file = ""
+config-file = second
+config-file =
+config-file = after-reset
+gtk-custom-css = "?required.css"
+gtk-custom-css = ?optional.css
+custom-shader = first.glsl
+custom-shader = ""
+custom-shader = second.glsl
+custom-shader = reset
+custom-shader = ignore
+`;
+
+      act(() => {
+        useConfigStore.getState().importConfig(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config['config-file']).toBe('after-reset');
+      expect(state.config['gtk-custom-css']).toEqual([
+        '"?required.css"',
+        '?optional.css',
+      ]);
+      expect(state.config['custom-shader']).toEqual([
+        'first.glsl',
+        'second.glsl',
+        'reset',
+        'ignore',
+      ]);
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).not.toContain('config-file = first');
+      expect(output).not.toContain('config-file = second');
+      expect(output).toContain('config-file = after-reset');
+      expect(output).toContain('gtk-custom-css = "?required.css"');
+      expect(output).toContain('gtk-custom-css = ?optional.css');
+      expect(output).toContain('custom-shader = first.glsl');
+      expect(output).toContain('custom-shader = second.glsl');
+      expect(output).toContain('custom-shader = reset');
+      expect(output).toContain('custom-shader = ignore');
+      expect(output).not.toContain('custom-shader = ""');
     });
 
     it('should handle indexed palette values', () => {
       const configString = `
 palette = 0=#000000
 palette = 1=ff0000
+palette = 0b10=red
+palette = 0o10=#111111
+palette = 0xF=ffffff
 `;
 
       act(() => {
@@ -191,7 +324,15 @@ palette = 1=ff0000
       expect(state.config['palette']).toEqual([
         '0=#000000',
         '1=#ff0000',
+        '2=red',
+        '8=#111111',
+        '15=#ffffff',
       ]);
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).toContain('palette = 2=red');
+      expect(output).toContain('palette = 8=#111111');
+      expect(output).toContain('palette = 15=#ffffff');
     });
 
     it('should skip comments and empty lines', () => {
@@ -209,6 +350,61 @@ font-size = 16
       const state = getStoreState();
       expect(state.config['font-size']).toBe(16);
     });
+
+    it('should treat empty known values as resets to Ghostty defaults', () => {
+      const configString = `
+font-size = 18
+font-size =
+cursor-style = bar
+cursor-style =
+font-family = JetBrains Mono
+font-family =
+keybind = ctrl+shift+t=new_tab
+keybind =
+`;
+
+      act(() => {
+        useConfigStore.getState().importConfig(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config).not.toHaveProperty('font-size');
+      expect(state.config).not.toHaveProperty('cursor-style');
+      expect(state.config).not.toHaveProperty('font-family');
+      expect(state.config).not.toHaveProperty('keybind');
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).not.toContain('font-size');
+      expect(output).not.toContain('cursor-style');
+      expect(output).not.toContain('font-family');
+      expect(output).not.toContain('keybind');
+    });
+
+    it('should omit imported known values that match Ghostty defaults', () => {
+      const configString = `
+font-size = 13
+desktop-notifications = true
+cursor-style = block
+font-synthetic-style = bold,italic,bold-italic
+unknown-option = true
+`;
+
+      act(() => {
+        useConfigStore.getState().importConfig(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config).toEqual({
+        'unknown-option': 'true',
+      });
+
+      const output = useConfigStore.getState().exportConfig();
+      expect(output).not.toContain('font-size');
+      expect(output).not.toContain('desktop-notifications');
+      expect(output).not.toContain('cursor-style');
+      expect(output).not.toContain('font-synthetic-style');
+      expect(output).toContain('unknown-option = true');
+    });
   });
 
   describe('exportConfig', () => {
@@ -222,7 +418,7 @@ font-size = 16
 
       expect(output).toContain('font-size = 16');
       expect(output).toContain('font-family = "JetBrains Mono"');
-      expect(output).toContain('# Generated by Spectre');
+      expect(output).toContain(`# Generated by Spectre v${SPECTRE_VERSION}`);
     });
 
     it('should not export default values', () => {

--- a/src/lib/store/config-store.ts
+++ b/src/lib/store/config-store.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import { useState, useEffect } from "react";
 import { allOptions } from "@/data/ghostty-options";
 import { normalizePaletteEntries } from "@/lib/utils/palette";
+import { SPECTRE_VERSION } from "@/lib/version";
 
 export type ConfigValues = Record<string, unknown>;
 
@@ -34,22 +35,84 @@ function getDefaultValue(key: string): unknown {
   return option?.default;
 }
 
+const PATH_OPTIONS = new Set([
+  "background-image",
+  "bell-audio-path",
+  "config-file",
+  "custom-shader",
+  "gtk-custom-css",
+]);
+
+function isPathOption(key: string): boolean {
+  return PATH_OPTIONS.has(key);
+}
+
+function isRepeatableOption(key: string): boolean {
+  const option = allOptions.find((opt) => opt.id === key);
+  if (!option) return false;
+  return (
+    option.type === "keybind" ||
+    option.type === "palette" ||
+    ("repeatable" in option && option.repeatable === true)
+  );
+}
+
+function stripDoubleQuotes(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function stripMatchingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+type ParsedPathValue =
+  | { kind: "reset" }
+  | { kind: "ignore" }
+  | { kind: "value"; value: string };
+
+function parsePathValue(rawValue: string): ParsedPathValue {
+  if (rawValue === "") {
+    return { kind: "reset" };
+  }
+
+  // Ghostty path parsing treats a leading ? as the optional-file marker before
+  // stripping double quotes. Therefore `?"foo"` is optional, while `"?foo"`
+  // is a required literal path beginning with ?.
+  if (rawValue.startsWith("?")) {
+    const path = stripDoubleQuotes(rawValue.slice(1));
+    return path.length === 0
+      ? { kind: "ignore" }
+      : { kind: "value", value: `?${path}` };
+  }
+
+  const unquoted = stripDoubleQuotes(rawValue);
+  if (unquoted.length === 0) {
+    return { kind: "ignore" };
+  }
+
+  return {
+    kind: "value",
+    value: unquoted.startsWith("?") ? `"${unquoted}"` : unquoted,
+  };
+}
+
 function normalizeValue(key: string, value: unknown): unknown {
   if (key === "palette" && Array.isArray(value)) {
     return normalizePaletteEntries(value as string[]);
   }
 
   return value;
-}
-
-function normalizeConfigValues(config: ConfigValues): ConfigValues {
-  const normalized: ConfigValues = { ...config };
-
-  for (const [key, value] of Object.entries(normalized)) {
-    normalized[key] = normalizeValue(key, value);
-  }
-
-  return normalized;
 }
 
 function valuesEqual(a: unknown, b: unknown): boolean {
@@ -60,10 +123,54 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   return a === b;
 }
 
+function shouldStoreValue(key: string, value: unknown): boolean {
+  const defaultValue = getDefaultValue(key);
+
+  // Unknown options do not have Spectre defaults; preserve them as raw strings.
+  if (defaultValue === undefined) {
+    return true;
+  }
+
+  if (valuesEqual(value, defaultValue) || (value === "" && defaultValue === "")) {
+    return false;
+  }
+
+  if (Array.isArray(value) && value.length === 0 && isRepeatableOption(key)) {
+    return false;
+  }
+
+  return true;
+}
+
+function normalizeConfigValues(config: ConfigValues): ConfigValues {
+  const normalized: ConfigValues = {};
+
+  for (const [key, value] of Object.entries(config)) {
+    const normalizedValue = normalizeValue(key, value);
+
+    if (shouldStoreValue(key, normalizedValue)) {
+      normalized[key] = normalizedValue;
+    }
+  }
+
+  return normalized;
+}
+
 // Parse a Ghostty config string into an object
 function parseConfig(configString: string): ConfigValues {
   const config: ConfigValues = {};
   const lines = configString.split("\n");
+
+  const appendValue = (key: string, value: string, alwaysArray = true) => {
+    const existing = config[key];
+    if (Array.isArray(existing)) {
+      existing.push(value);
+    } else if (existing !== undefined) {
+      config[key] = [existing, value];
+    } else {
+      config[key] = alwaysArray ? [value] : value;
+    }
+  };
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -78,20 +185,25 @@ function parseConfig(configString: string): ConfigValues {
     if (equalsIndex === -1) continue;
 
     const key = trimmed.slice(0, equalsIndex).trim();
-    let value: string | boolean | number = trimmed.slice(equalsIndex + 1).trim();
-
-    // Remove quotes if present
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
+    const rawValue = trimmed.slice(equalsIndex + 1).trim();
 
     // Find the option to determine proper type
     const option = allOptions.find((opt) => opt.id === key);
+    const parsedPathValue = option && isPathOption(key) ? parsePathValue(rawValue) : null;
 
     if (option) {
+      if (parsedPathValue?.kind === "ignore") {
+        continue;
+      }
+
+      // In Ghostty, empty known values reset that key to its default.
+      if (rawValue === "" || parsedPathValue?.kind === "reset") {
+        delete config[key];
+        continue;
+      }
+
+      const value = parsedPathValue?.kind === "value" ? parsedPathValue.value : stripMatchingQuotes(rawValue);
+
       // Convert value to proper type
       switch (option.type) {
         case "boolean":
@@ -103,17 +215,21 @@ function parseConfig(configString: string): ConfigValues {
         case "keybind":
         case "palette":
           // These are repeatable, accumulate values
-          if (!config[key]) {
-            config[key] = [];
+          appendValue(key, value as string);
+          break;
+        case "string":
+          if (option.repeatable) {
+            appendValue(key, value as string, false);
+          } else {
+            config[key] = value;
           }
-          (config[key] as string[]).push(value as string);
           break;
         default:
           config[key] = value;
       }
     } else {
       // Unknown option, store as string
-      config[key] = value;
+      config[key] = stripMatchingQuotes(rawValue);
     }
   }
 
@@ -135,8 +251,14 @@ function formatValue(key: string, value: unknown): string {
     return value ? "true" : "false";
   }
 
-  if (typeof value === "string" && value.includes(" ")) {
-    return `"${value}"`;
+  if (typeof value === "string") {
+    if (isPathOption(key) && (value.startsWith("?") || value.startsWith('"?'))) {
+      return value;
+    }
+
+    if (value.includes(" ")) {
+      return `"${value}"`;
+    }
   }
 
   return String(value);
@@ -150,16 +272,15 @@ export const useConfigStore = create<ConfigStore>()(
 
       setValue: (key: string, value: unknown) => {
         const normalizedValue = normalizeValue(key, value);
-        const defaultValue = getDefaultValue(key);
 
         set((state) => {
           const newConfig = { ...state.config };
 
           // If value equals default, remove from config
-          if (valuesEqual(normalizedValue, defaultValue) || (normalizedValue === "" && defaultValue === "")) {
-            delete newConfig[key];
-          } else {
+          if (shouldStoreValue(key, normalizedValue)) {
             newConfig[key] = normalizedValue;
+          } else {
+            delete newConfig[key];
           }
 
           return { config: newConfig };
@@ -211,7 +332,7 @@ export const useConfigStore = create<ConfigStore>()(
       exportConfig: () => {
         const { config, appliedTheme } = get();
         const lines: string[] = [
-          "# Generated by Spectre - Ghostty Config Generator",
+          `# Generated by Spectre v${SPECTRE_VERSION} - Ghostty Config Generator`,
           "# https://github.com/imrajyavardhan12/spectre-ghostty-config",
         ];
         

--- a/src/lib/utils/keybind-validation.test.ts
+++ b/src/lib/utils/keybind-validation.test.ts
@@ -262,6 +262,12 @@ describe('keybind-validation', () => {
       const result = validateKeybind('global:ctrl+shift+n=new_window');
       expect(result.valid).toBe(true);
     });
+
+    it('should allow Ghostty special keybind reset values', () => {
+      const result = validateKeybind('clear');
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
   });
 
   describe('KEYBIND_ACTIONS', () => {

--- a/src/lib/utils/keybind-validation.ts
+++ b/src/lib/utils/keybind-validation.ts
@@ -18,6 +18,10 @@ const TRIGGER_PREFIXES = new Set([
   "physical",
 ]);
 
+// Special keybind values accepted by Ghostty in place of trigger=action.
+// Source: Ghostty Config.zig documents `keybind=clear` to clear all keybindings.
+const SPECIAL_KEYBIND_VALUES = new Set(["clear"]);
+
 // Common function/special keys (from W3C spec)
 const SPECIAL_KEYS = new Set([
   // Function keys
@@ -806,8 +810,13 @@ export function validateKeybind(keybind: string): ValidationResult {
     return { valid: false, errors: ["Keybind cannot be empty"], warnings: [] };
   }
 
+  const trimmedKeybind = keybind.trim();
+  if (SPECIAL_KEYBIND_VALUES.has(trimmedKeybind)) {
+    return result;
+  }
+
   // Split by = to get trigger and action
-  const equalsIndex = keybind.indexOf("=");
+  const equalsIndex = trimmedKeybind.indexOf("=");
 
   if (equalsIndex === -1) {
     return {
@@ -817,8 +826,8 @@ export function validateKeybind(keybind: string): ValidationResult {
     };
   }
 
-  const trigger = keybind.slice(0, equalsIndex).trim();
-  const action = keybind.slice(equalsIndex + 1).trim();
+  const trigger = trimmedKeybind.slice(0, equalsIndex).trim();
+  const action = trimmedKeybind.slice(equalsIndex + 1).trim();
 
   // Handle trigger sequences (e.g., ctrl+a>n)
   const triggerParts = trigger.split(">").map(t => t.trim()).filter(t => t);

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import packageJson from '../../package.json';
+import { SPECTRE_VERSION } from '@/lib/version';
+
+describe('Spectre product version', () => {
+  it('matches package.json', () => {
+    expect(SPECTRE_VERSION).toBe(packageJson.version);
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const SPECTRE_VERSION = "0.2.0";


### PR DESCRIPTION
## Summary

- Harden Ghostty config import/export roundtrips for quoted strings, repeatable strings, repeatable path options, palettes, keybinds, unknown options, default values, and empty-value resets.
- Align schema/parser behavior with official Ghostty docs/source for `font-family`, `env`, `palette`, `keybind = clear`, `config-file`, `custom-shader`, and `gtk-custom-css`.
- Add Spectre product versioning for `v0.2.0`, including exported config header, UI display, changelog, and version sync test.

## Ghostty source-of-truth checks

Verified changed semantics against:

- https://ghostty.org/docs/config
- https://ghostty.org/docs/config/reference
- https://github.com/ghostty-org/ghostty/blob/main/src/config/Config.zig
- https://github.com/ghostty-org/ghostty/blob/main/src/config/path.zig

## Verification

```bash
bun run test -- --run
bun run typecheck
bun run lint
bun run build
bun install --frozen-lockfile
git diff --check
```

Known lint output remains one pre-existing warning for the Buy Me A Coffee raw `<img>` in `src/app/page.tsx`.
