### PR TITLE
Add security headers, CSP, and shared-config hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Added a repeatable text input for Ghostty string options that can be specified multiple times, such as `font-family`, `env`, `config-file`, `custom-shader`, and `gtk-custom-css`.
 - Added source-backed inline validation diagnostics for Ghostty color, duration, and number settings.
 - Added a Ghostty schema drift check script and weekly workflow that compare local option IDs against the official config reference.
+- Added a `src/lib/security/` module that builds a strict Content Security Policy and a full security header set, with separate dev and prod variants.
+- Added a runtime shape validator for shared configuration URLs that drops unknown option keys, coerces values to their schema type, rejects prototype-pollution payloads, and bounds payload size.
+- Added unit tests covering the new CSP, headers, and shared-config validators.
 
 ### Changed
 
@@ -23,6 +26,9 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Updated CI checkout actions to `actions/checkout@v5`.
 - Added dependency overrides for vulnerable transitive packages and removed unused `copy-webpack-plugin`.
 - Shared configuration pages now preview/export the shared config without overwriting the user's persisted editor state; the config is only loaded when the user opens it in the editor.
+- `next.config.ts` now applies a strict set of security headers to every route: `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, and `Cross-Origin-Embedder-Policy` (prod only).
+- `decodeConfig` now normalises share payloads to a known shape (no prototype chain, no unknown keys, no non-primitive values); a missing theme is now `null` everywhere instead of `undefined`.
+- `fetchThemeList` and `fetchTheme` now assert a textual `content-type` and stream the response with a 256 KB byte cap to prevent hostile or compromised upstreams from streaming arbitrary content into the parser.
 
 ### Fixed
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 import { buildSecurityHeaders } from "./src/lib/security/headers";
 
+// SECURITY: `process.env.NODE_ENV` is read at config-evaluation time,
+// which Next.js runs at build time (not per request). That means the
+// dev-vs-prod split below is locked in when the build is produced.
+// `next start` must be invoked with `NODE_ENV=production` (the script
+// in package.json does this) or it will ship the dev CSP.
 const isDev = process.env.NODE_ENV !== "production";
 const { headers: securityHeaders } = buildSecurityHeaders(isDev);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,27 @@
 import type { NextConfig } from "next";
+import { buildSecurityHeaders } from "./src/lib/security/headers";
+
+const isDev = process.env.NODE_ENV !== "production";
+const { headers: securityHeaders } = buildSecurityHeaders(isDev);
 
 const nextConfig: NextConfig = {
   // Enable Turbopack with empty config to allow default behavior
   turbopack: {},
+
+  // Apply a single, auditable set of security headers to every route.
+  // The header values are built in src/lib/security/headers.ts; any new
+  // header (or change to an existing one) should be made there.
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: Object.entries(securityHeaders).map(([key, value]) => ({
+          key,
+          value,
+        })),
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { buildCsp, parseCsp } from "@/lib/security/csp";
+
+describe("buildCsp", () => {
+  it("includes the baseline directives in production mode", () => {
+    const csp = buildCsp(false);
+    const parsed = parseCsp(csp);
+
+    expect(parsed["default-src"]).toEqual(["'self'"]);
+    expect(parsed["frame-ancestors"]).toEqual(["'none'"]);
+    expect(parsed["base-uri"]).toEqual(["'self'"]);
+    expect(parsed["form-action"]).toEqual(["'self'"]);
+    expect(parsed["object-src"]).toEqual(["'none'"]);
+    expect(parsed["media-src"]).toEqual(["'none'"]);
+    expect(parsed["manifest-src"]).toEqual(["'self'"]);
+  });
+
+  it("lists every external origin the app actually uses in production", () => {
+    const parsed = parseCsp(buildCsp(false));
+
+    const scriptSrc = parsed["script-src"].join(" ");
+    expect(scriptSrc).toContain("https://*.vercel-insights.com");
+    expect(scriptSrc).toContain("https://*.vercel.com");
+    expect(scriptSrc).toContain("blob:");
+
+    const connectSrc = parsed["connect-src"].join(" ");
+    expect(connectSrc).toContain("https://api.github.com");
+    expect(connectSrc).toContain("https://raw.githubusercontent.com");
+
+    const imgSrc = parsed["img-src"].join(" ");
+    expect(imgSrc).toContain("https://cdn.buymeacoffee.com");
+    expect(imgSrc).toContain("data:");
+  });
+
+  it("sets upgrade-insecure-requests in production", () => {
+    const parsed = parseCsp(buildCsp(false));
+    expect(parsed["upgrade-insecure-requests"]).toBeDefined();
+  });
+
+  it("does not include upgrade-insecure-requests in development", () => {
+    const parsed = parseCsp(buildCsp(true));
+    expect(parsed["upgrade-insecure-requests"]).toBeUndefined();
+  });
+
+  it("allows HMR primitives only in development", () => {
+    const prod = parseCsp(buildCsp(false));
+    const dev = parseCsp(buildCsp(true));
+
+    expect(prod["script-src"]).not.toContain("'unsafe-eval'");
+    expect(dev["script-src"]).toContain("'unsafe-eval'");
+
+    expect(prod["connect-src"]).not.toContain("ws:");
+    expect(dev["connect-src"]).toContain("ws:");
+    expect(dev["connect-src"]).toContain("wss:");
+
+    expect(prod["connect-src"]).not.toContain("http://localhost:*");
+    expect(dev["connect-src"]).toContain("http://localhost:*");
+  });
+
+  it("does not require the Google Fonts hosts (next/font self-hosts)", () => {
+    const parsed = parseCsp(buildCsp(false));
+    const fontSrc = parsed["font-src"].join(" ");
+    const styleSrc = parsed["style-src"].join(" ");
+
+    expect(fontSrc).not.toContain("fonts.gstatic.com");
+    expect(styleSrc).not.toContain("fonts.googleapis.com");
+  });
+
+  it("allows WASM helpers via blob: in script-src and worker-src", () => {
+    const parsed = parseCsp(buildCsp(false));
+    expect(parsed["script-src"]).toContain("blob:");
+    expect(parsed["worker-src"]).toContain("blob:");
+  });
+});
+
+describe("parseCsp", () => {
+  it("round-trips a real CSP value", () => {
+    const csp = "default-src 'self'; script-src 'self' 'unsafe-inline' blob:; object-src 'none'";
+    const parsed = parseCsp(csp);
+    expect(parsed["default-src"]).toEqual(["'self'"]);
+    expect(parsed["script-src"]).toEqual(["'self'", "'unsafe-inline'", "blob:"]);
+    expect(parsed["object-src"]).toEqual(["'none'"]);
+  });
+
+  it("ignores empty directive segments", () => {
+    const parsed = parseCsp("default-src 'self';;; object-src 'none'");
+    expect(parsed["default-src"]).toEqual(["'self'"]);
+    expect(parsed["object-src"]).toEqual(["'none'"]);
+  });
+});

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -66,6 +66,12 @@ describe("buildCsp", () => {
     expect(styleSrc).not.toContain("fonts.googleapis.com");
   });
 
+  it("allows WASM compilation without reopening broad JavaScript eval in production", () => {
+    const parsed = parseCsp(buildCsp(false));
+    expect(parsed["script-src"]).toContain("'wasm-unsafe-eval'");
+    expect(parsed["script-src"]).not.toContain("'unsafe-eval'");
+  });
+
   it("allows WASM helpers via blob: in script-src and worker-src", () => {
     const parsed = parseCsp(buildCsp(false));
     expect(parsed["script-src"]).toContain("blob:");

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,143 @@
+// Content Security Policy builder.
+//
+// Spectre loads resources from a small, fixed set of origins. The policy below
+// reflects exactly what the app needs - nothing more. Any new external
+// dependency MUST be added here with a justification comment, otherwise it
+// will be blocked in production.
+//
+// References:
+//   - https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+//   - https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
+
+/**
+ * Build a Content-Security-Policy header value.
+ *
+ * @param isDev `true` relaxes the policy for local development (HMR, eval,
+ *   inline styles, the Vercel CLI inspector). Production builds use the
+ *   strict policy regardless of `process.env.NODE_ENV`, so callers can also
+ *   use this to preview the prod policy.
+ *
+ * Notes on each directive:
+ *
+ *   - default-src 'self': baseline; everything not explicitly allowed is
+ *     blocked.
+ *   - script-src 'self' 'unsafe-inline' https://*.vercel-insights.com
+ *     https://*.vercel.com blob::
+ *     - 'unsafe-inline' is currently required by Next.js' inline hydration
+ *       scripts and by dynamically-injected styles for the WASM-backed
+ *       terminal preview. Upgrading to nonce-based scripts is tracked as
+ *       follow-up work; see TODO in headers.ts.
+ *     - blob: is required for the libghostty WASM module which loads its
+ *       helpers via blob URLs.
+ *     - Vercel Analytics + Speed Insights ship tiny inline scripts that
+ *       phone home; we allow only the official Vercel domains.
+ *   - style-src 'self' 'unsafe-inline':
+ *     - 'unsafe-inline' is required for Tailwind's emitted styles and
+ *       shadcn/ui's Radix primitives that set inline styles.
+ *   - img-src 'self' data: https: https://cdn.buymeacoffee.com:
+ *     - `data:` is required for the Ghostty preview's binary image data
+ *       and for several SVG icons.
+ *     - `https:` is broad; the app pulls user-driven screenshots and
+ *       theme preview swatches from arbitrary HTTPS origins. Tighten to
+ *       a list if a content whitelist is ever desired.
+ *   - font-src 'self' data::
+ *     - `next/font/google` self-hosts Inter at build time, so Google
+ *       Fonts domains are NOT required.
+ *     - `data:` is needed for inlined icon fonts.
+ *   - connect-src 'self' https://api.github.com https://raw.githubusercontent.com
+ *     https://*.vercel-insights.com:
+ *     - The themes feature fetches the iTerm2-Color-Schemes repository
+ *       over the GitHub API and raw content hosts.
+ *   - worker-src 'self' blob::
+ *     - The libghostty WASM terminal spawns a Web Worker that uses
+ *       blob: URLs for its helpers.
+ *   - frame-ancestors 'none': disable embedding (anti-clickjacking).
+ *     This is also reinforced by X-Frame-Options for older browsers.
+ *   - base-uri 'self': prevent <base> tag injection which could
+ *     re-anchor all relative URLs to an attacker-controlled origin.
+ *   - form-action 'self': any future forms can only POST to our origin.
+ *   - object-src 'none': no Flash, no <object>/<embed> content.
+ *   - media-src 'none': the app has no audio/video.
+ *   - manifest-src 'self': PWA manifest (if/when added) must be same-origin.
+ *   - upgrade-insecure-requests: in prod, silently upgrade any stray
+ *     http:// subresource to https://.
+ */
+export function buildCsp(isDev: boolean): string {
+  const directives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "https://*.vercel-insights.com",
+      "https://*.vercel.com",
+      "blob:",
+    ],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": [
+      "'self'",
+      "data:",
+      "https:",
+      "https://cdn.buymeacoffee.com",
+    ],
+    "font-src": ["'self'", "data:"],
+    "connect-src": [
+      "'self'",
+      "https://api.github.com",
+      "https://raw.githubusercontent.com",
+      "https://*.vercel-insights.com",
+      "https://*.vercel.com",
+    ],
+    "worker-src": ["'self'", "blob:"],
+    "frame-ancestors": ["'none'"],
+    "base-uri": ["'self'"],
+    "form-action": ["'self'"],
+    "object-src": ["'none'"],
+    "media-src": ["'none'"],
+    "manifest-src": ["'self'"],
+  };
+
+  if (isDev) {
+    // Development needs:
+    //   - 'unsafe-eval' for webpack/turbopack HMR
+    //   - ws: / wss: for the HMR WebSocket
+    //   - http: localhost and 127.0.0.1 (Next.js dev server)
+    directives["script-src"] = [
+      ...directives["script-src"],
+      "'unsafe-eval'",
+    ];
+    directives["connect-src"] = [
+      ...directives["connect-src"],
+      "ws:",
+      "wss:",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ];
+  } else {
+    // Production: force any accidentally-included http:// subresource to
+    // upgrade to https. Browsers ignore this directive over HTTP itself,
+    // so it's harmless on localhost.
+    directives["upgrade-insecure-requests"] = [];
+  }
+
+  return Object.entries(directives)
+    .map(([key, values]) =>
+      values.length === 0 ? key : `${key} ${values.join(" ")}`
+    )
+    .join("; ");
+}
+
+/**
+ * Parse a CSP header value back into a structured form. Useful for tests
+ * and for tooling that wants to assert the presence of a directive.
+ */
+export function parseCsp(header: string): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  for (const directive of header.split(";").map((d) => d.trim())) {
+    if (!directive) continue;
+    const [key, ...valueParts] = directive.split(/\s+/);
+    result[key] = valueParts;
+  }
+
+  return result;
+}

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -25,8 +25,9 @@
  *     https://*.vercel.com blob::
  *     - 'unsafe-inline' is currently required by Next.js' inline hydration
  *       scripts and by dynamically-injected styles for the WASM-backed
- *       terminal preview. Upgrading to nonce-based scripts is tracked as
- *       follow-up work; see TODO in headers.ts.
+ *       terminal preview. Upgrading to nonce-based scripts is a known
+ *       follow-up; left as a future task because it requires middleware
+ *       changes.
  *     - blob: is required for the libghostty WASM module which loads its
  *       helpers via blob URLs.
  *     - Vercel Analytics + Speed Insights ship tiny inline scripts that
@@ -34,12 +35,11 @@
  *   - style-src 'self' 'unsafe-inline':
  *     - 'unsafe-inline' is required for Tailwind's emitted styles and
  *       shadcn/ui's Radix primitives that set inline styles.
- *   - img-src 'self' data: https: https://cdn.buymeacoffee.com:
+ *   - img-src 'self' data: https://cdn.buymeacoffee.com:
  *     - `data:` is required for the Ghostty preview's binary image data
  *       and for several SVG icons.
- *     - `https:` is broad; the app pulls user-driven screenshots and
- *       theme preview swatches from arbitrary HTTPS origins. Tighten to
- *       a list if a content whitelist is ever desired.
+ *     - The only external image Spectre loads is the Buy Me a Coffee
+ *       button, so the allowlist is explicit rather than `https:`.
  *   - font-src 'self' data::
  *     - `next/font/google` self-hosts Inter at build time, so Google
  *       Fonts domains are NOT required.
@@ -76,7 +76,6 @@ export function buildCsp(isDev: boolean): string {
     "img-src": [
       "'self'",
       "data:",
-      "https:",
       "https://cdn.buymeacoffee.com",
     ],
     "font-src": ["'self'", "data:"],

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -21,13 +21,15 @@
  *
  *   - default-src 'self': baseline; everything not explicitly allowed is
  *     blocked.
- *   - script-src 'self' 'unsafe-inline' https://*.vercel-insights.com
- *     https://*.vercel.com blob::
+ *   - script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'
+ *     https://*.vercel-insights.com https://*.vercel.com blob::
  *     - 'unsafe-inline' is currently required by Next.js' inline hydration
  *       scripts and by dynamically-injected styles for the WASM-backed
  *       terminal preview. Upgrading to nonce-based scripts is a known
  *       follow-up; left as a future task because it requires middleware
  *       changes.
+ *     - 'wasm-unsafe-eval' allows libghostty's same-origin WebAssembly
+ *       module to compile without reopening broad JavaScript eval.
  *     - blob: is required for the libghostty WASM module which loads its
  *       helpers via blob URLs.
  *     - Vercel Analytics + Speed Insights ship tiny inline scripts that
@@ -68,6 +70,7 @@ export function buildCsp(isDev: boolean): string {
     "script-src": [
       "'self'",
       "'unsafe-inline'",
+      "'wasm-unsafe-eval'",
       "https://*.vercel-insights.com",
       "https://*.vercel.com",
       "blob:",

--- a/src/lib/security/headers.test.ts
+++ b/src/lib/security/headers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildSecurityHeaders } from "@/lib/security/headers";
+
+describe("buildSecurityHeaders", () => {
+  it("includes the canonical header set in production", () => {
+    const { headers } = buildSecurityHeaders(false);
+
+    expect(headers["X-Frame-Options"]).toBe("DENY");
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(headers["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+    expect(headers["Cross-Origin-Opener-Policy"]).toBe("same-origin");
+    expect(headers["Cross-Origin-Resource-Policy"]).toBe("same-origin");
+    expect(headers["Strict-Transport-Security"]).toContain("max-age=63072000");
+    expect(headers["Content-Security-Policy"]).toBeDefined();
+  });
+
+  it("sets a strict COEP in production", () => {
+    const { headers } = buildSecurityHeaders(false);
+    // credentialless is the right pick for an app that loads same-origin
+    // WASM alongside cross-origin user-driven images.
+    expect(headers["Cross-Origin-Embedder-Policy"]).toBe("credentialless");
+  });
+
+  it("omits COEP in development to avoid breaking Turbopack", () => {
+    const { headers } = buildSecurityHeaders(true);
+    expect(headers["Cross-Origin-Embedder-Policy"]).toBeUndefined();
+  });
+
+  it("disables browser features Spectre does not need", () => {
+    const { headers } = buildSecurityHeaders(false);
+    const policy = headers["Permissions-Policy"];
+
+    expect(policy).toBeDefined();
+    for (const feature of [
+      "camera",
+      "microphone",
+      "geolocation",
+      "payment",
+      "usb",
+    ]) {
+      expect(policy).toContain(`${feature}=()`);
+    }
+  });
+
+  it("still sets HSTS in development (browsers ignore it over HTTP)", () => {
+    const { headers } = buildSecurityHeaders(true);
+    expect(headers["Strict-Transport-Security"]).toContain("max-age=63072000");
+  });
+
+  it("CSP is stricter in production than in development", () => {
+    const { headers: prod } = buildSecurityHeaders(false);
+    const { headers: dev } = buildSecurityHeaders(true);
+
+    expect(dev["Content-Security-Policy"]).toContain("'unsafe-eval'");
+    expect(prod["Content-Security-Policy"]).not.toContain("'unsafe-eval'");
+  });
+});

--- a/src/lib/security/headers.ts
+++ b/src/lib/security/headers.ts
@@ -69,7 +69,7 @@ export function buildSecurityHeaders(isDev: boolean): SecurityHeaderSet {
     // HSTS: 2 years, include subdomains, eligible for preload. Vercel
     // already sets HSTS by default, but we set it explicitly so the
     // policy is auditable in this file. Safe to ship in dev as well -
-    // browsers only honour HSTS over HTTPS.
+    // browsers ignore HSTS over plain HTTP.
     "Strict-Transport-Security":
       "max-age=63072000; includeSubDomains; preload",
 

--- a/src/lib/security/headers.ts
+++ b/src/lib/security/headers.ts
@@ -1,0 +1,94 @@
+// Security header construction for Spectre.
+//
+// All HTTP security headers are centralised here so the policy lives in one
+// auditable place. The set follows the OWASP Secure Headers Project
+// recommendations (https://owasp.org/www-project-secure-headers/) and is
+// tailored to Spectre's specific threat model.
+
+import { buildCsp } from "./csp";
+
+export interface SecurityHeaderSet {
+  /** Header name -> header value */
+  headers: Record<string, string>;
+}
+
+/**
+ * Build the full set of security headers for a request.
+ *
+ * @param isDev `true` relaxes the CSP to allow HMR and dev-only origins.
+ *   All other headers are identical in dev and prod.
+ */
+export function buildSecurityHeaders(isDev: boolean): SecurityHeaderSet {
+  const headers: Record<string, string> = {
+    // Defence-in-depth against clickjacking. Modern browsers honour
+    // CSP frame-ancestors; X-Frame-Options covers older ones.
+    "X-Frame-Options": "DENY",
+
+    // Block MIME-type sniffing - critical for any user-uploaded content
+    // (in our case: imported config files and the shared URL payload).
+    "X-Content-Type-Options": "nosniff",
+
+    // Don't expose the full URL (which can include sensitive path/query
+    // parameters) to third parties.
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+
+    // Disable browser features Spectre has no business using. Locking
+    // these down shrinks the attack surface if a future XSS slips through.
+    "Permissions-Policy": [
+      "accelerometer=()",
+      "autoplay=()",
+      "browsing-topics=()",
+      "camera=()",
+      "cross-origin-isolated=()",
+      "display-capture=()",
+      "encrypted-media=()",
+      "fullscreen=(self)",
+      "geolocation=()",
+      "gyroscope=()",
+      "keyboard-map=()",
+      "magnetometer=()",
+      "microphone=()",
+      "midi=()",
+      "payment=()",
+      "picture-in-picture=()",
+      "publickey-credentials-get=()",
+      "screen-wake-lock=()",
+      "sync-xhr=()",
+      "usb=()",
+      "xr-spatial-tracking=()",
+    ].join(", "),
+
+    // Prevent the page from being opened in a pop-up by another origin and
+    // then having window.opener hijacked. Required for full isolation.
+    "Cross-Origin-Opener-Policy": "same-origin",
+
+    // Block no-cors cross-origin embeds of our resources. We don't need
+    // to be embeddable from third-party origins.
+    "Cross-Origin-Resource-Policy": "same-origin",
+
+    // HSTS: 2 years, include subdomains, eligible for preload. Vercel
+    // already sets HSTS by default, but we set it explicitly so the
+    // policy is auditable in this file. Safe to ship in dev as well -
+    // browsers only honour HSTS over HTTPS.
+    "Strict-Transport-Security":
+      "max-age=63072000; includeSubDomains; preload",
+
+    // Content-Security-Policy. See csp.ts for the directive-level
+    // rationale.
+    "Content-Security-Policy": buildCsp(isDev),
+  };
+
+  // Cross-Origin-Embedder-Policy: credentialless is the right pick for an
+  // app that loads a same-origin WASM module alongside user-driven
+  // cross-origin images. The strict `require-corp` value would force us
+  // to add CORP/CORS headers to every external image.
+  //
+  // We do NOT set this in dev because the local Turbopack dev server
+  // doesn't always emit the right CORP headers, and `credentialless`
+  // has historically had inconsistent behaviour with localhost.
+  if (!isDev) {
+    headers["Cross-Origin-Embedder-Policy"] = "credentialless";
+  }
+
+  return { headers };
+}

--- a/src/lib/security/validate-shared-config.test.ts
+++ b/src/lib/security/validate-shared-config.test.ts
@@ -12,6 +12,32 @@ describe("validateSharedConfig", () => {
     expect(result.dropped).toEqual([]);
   });
 
+  it("accepts string arrays for repeatable string options", () => {
+    const result = validateSharedConfig({
+      "font-family": ["JetBrains Mono", "Symbols Nerd Font"],
+      env: ["PATH=/usr/local/bin", "EDITOR=nvim"],
+      "config-file": ["?local", "/etc/ghostty/config"],
+    });
+
+    expect(result.config).toEqual({
+      "font-family": ["JetBrains Mono", "Symbols Nerd Font"],
+      env: ["PATH=/usr/local/bin", "EDITOR=nvim"],
+      "config-file": ["?local", "/etc/ghostty/config"],
+    });
+    expect(result.dropped).toEqual([]);
+  });
+
+  it("rejects string arrays for non-repeatable string options", () => {
+    const result = validateSharedConfig({
+      title: ["not", "repeatable"],
+    });
+
+    expect(result.config).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: "title", reason: "invalid value shape" },
+    ]);
+  });
+
   it("accepts a known number option", () => {
     const result = validateSharedConfig({ "font-size": 14 });
     expect(result.config).toEqual({ "font-size": 14 });
@@ -59,8 +85,13 @@ describe("validateSharedConfig", () => {
     expect(result.config).toEqual({ background: "#fff" });
   });
 
-  it("rejects a color value that is neither hex nor an X11 name", () => {
-    const result = validateSharedConfig({ background: "<script>alert(1)</script>" });
+  it("accepts Ghostty X11 color names through the shared editor validator", () => {
+    const result = validateSharedConfig({ background: "medium spring green" });
+    expect(result.config).toEqual({ background: "medium spring green" });
+  });
+
+  it("rejects a color value that is neither hex nor a Ghostty X11 name", () => {
+    const result = validateSharedConfig({ background: "not a real color" });
     expect(result.config).toEqual({});
     expect(result.dropped).toEqual([
       { key: "background", reason: "invalid value shape" },
@@ -101,6 +132,11 @@ describe("validateSharedConfig", () => {
     expect(result.config).toEqual({
       keybind: ["ctrl+c=copy_to_clipboard", "ctrl+v=paste_from_clipboard"],
     });
+  });
+
+  it("accepts Ghostty's special keybind clear value", () => {
+    const result = validateSharedConfig({ keybind: ["clear"] });
+    expect(result.config).toEqual({ keybind: ["clear"] });
   });
 
   it("rejects a keybind entry with no '=' separator", () => {
@@ -166,6 +202,13 @@ describe("validateSharedConfig", () => {
       "resize-overlay-duration": "1h30m",
     });
     expect(result.config).toEqual({ "resize-overlay-duration": "1h30m" });
+  });
+
+  it("accepts duration whitespace forms supported by the editor validator", () => {
+    const result = validateSharedConfig({
+      "resize-overlay-duration": "1 h 30 m",
+    });
+    expect(result.config).toEqual({ "resize-overlay-duration": "1 h 30 m" });
   });
 
   it("rejects a duration with no unit", () => {

--- a/src/lib/security/validate-shared-config.test.ts
+++ b/src/lib/security/validate-shared-config.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSharedConfig,
+  validateSharedThemeName,
+  SHARED_CONFIG_LIMITS,
+} from "@/lib/security/validate-shared-config";
+
+describe("validateSharedConfig", () => {
+  it("accepts a known string option", () => {
+    const result = validateSharedConfig({ "font-family": "JetBrains Mono" });
+    expect(result.config).toEqual({ "font-family": "JetBrains Mono" });
+    expect(result.dropped).toEqual([]);
+  });
+
+  it("accepts a known number option", () => {
+    const result = validateSharedConfig({ "font-size": 14 });
+    expect(result.config).toEqual({ "font-size": 14 });
+  });
+
+  it("coerces a numeric string for a number option", () => {
+    const result = validateSharedConfig({ "font-size": "16" });
+    expect(result.config).toEqual({ "font-size": 16 });
+  });
+
+  it("accepts a known boolean option", () => {
+    const result = validateSharedConfig({ "mouse-hide-while-typing": true });
+    expect(result.config).toEqual({ "mouse-hide-while-typing": true });
+  });
+
+  it("coerces 'true'/'false' strings for boolean options", () => {
+    const a = validateSharedConfig({ "mouse-hide-while-typing": "true" });
+    const b = validateSharedConfig({ "mouse-hide-while-typing": "false" });
+    expect(a.config).toEqual({ "mouse-hide-while-typing": true });
+    expect(b.config).toEqual({ "mouse-hide-while-typing": false });
+  });
+
+  it("drops enum values that aren't in the allowed list", () => {
+    const result = validateSharedConfig({ "cursor-style": "rainbow" });
+    expect(result.config).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: "cursor-style", reason: "invalid value shape" },
+    ]);
+  });
+
+  it("accepts an enum value from the schema", () => {
+    const result = validateSharedConfig({ "cursor-style": "bar" });
+    expect(result.config).toEqual({ "cursor-style": "bar" });
+  });
+
+  it("accepts a hex color with or without #", () => {
+    const a = validateSharedConfig({ background: "#1a1b26" });
+    const b = validateSharedConfig({ background: "1a1b26" });
+    expect(a.config).toEqual({ background: "#1a1b26" });
+    expect(b.config).toEqual({ background: "1a1b26" });
+  });
+
+  it("accepts a short hex color", () => {
+    const result = validateSharedConfig({ background: "#fff" });
+    expect(result.config).toEqual({ background: "#fff" });
+  });
+
+  it("rejects a color value that is neither hex nor an X11 name", () => {
+    const result = validateSharedConfig({ background: "<script>alert(1)</script>" });
+    expect(result.config).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: "background", reason: "invalid value shape" },
+    ]);
+  });
+
+  it("accepts a valid palette array of N=COLOR entries", () => {
+    const result = validateSharedConfig({
+      palette: ["0=#000000", "1=#cc0000", "15=#eeeeec"],
+    });
+    expect(result.config).toEqual({
+      palette: ["0=#000000", "1=#cc0000", "15=#eeeeec"],
+    });
+  });
+
+  it("accepts a single palette string (promoted to a one-element array)", () => {
+    const result = validateSharedConfig({ palette: "0=#000000" });
+    expect(result.config).toEqual({ palette: ["0=#000000"] });
+  });
+
+  it("rejects a palette entry missing the index prefix", () => {
+    const result = validateSharedConfig({ palette: ["#000000"] });
+    expect(result.config).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: "palette", reason: "invalid value shape" },
+    ]);
+  });
+
+  it("rejects a palette entry with a non-numeric index", () => {
+    const result = validateSharedConfig({ palette: ["abc=#000000"] });
+    expect(result.config).toEqual({});
+  });
+
+  it("accepts a keybind array of trigger=action strings", () => {
+    const result = validateSharedConfig({
+      keybind: ["ctrl+c=copy_to_clipboard", "ctrl+v=paste_from_clipboard"],
+    });
+    expect(result.config).toEqual({
+      keybind: ["ctrl+c=copy_to_clipboard", "ctrl+v=paste_from_clipboard"],
+    });
+  });
+
+  it("rejects a keybind entry with no '=' separator", () => {
+    const result = validateSharedConfig({ keybind: ["ctrl+c"] });
+    expect(result.config).toEqual({});
+  });
+
+  it("drops unknown option keys", () => {
+    const result = validateSharedConfig({
+      "not-a-real-option": "anything",
+    });
+    expect(result.config).toEqual({});
+    expect(result.dropped).toEqual([
+      { key: "not-a-real-option", reason: "unknown option" },
+    ]);
+  });
+
+  it("rejects prototype-pollution key names", () => {
+    for (const dangerous of ["__proto__", "constructor", "prototype"]) {
+      const result = validateSharedConfig({ [dangerous]: "value" });
+      expect(result.config).toEqual({});
+      expect(result.dropped.some((d) => d.key === dangerous)).toBe(true);
+    }
+  });
+
+  it("rejects a non-object root", () => {
+    expect(validateSharedConfig(null).config).toEqual({});
+    expect(validateSharedConfig(undefined).config).toEqual({});
+    expect(validateSharedConfig("a string").config).toEqual({});
+    expect(validateSharedConfig(42).config).toEqual({});
+    expect(validateSharedConfig([]).config).toEqual({});
+  });
+
+  it("rejects a config with more than the key cap", () => {
+    const tooBig: Record<string, number> = {};
+    for (let i = 0; i < SHARED_CONFIG_LIMITS.maxKeys + 1; i++) {
+      tooBig[`k${i}`] = i;
+    }
+    const result = validateSharedConfig(tooBig);
+    expect(result.config).toEqual({});
+    expect(result.dropped[0].reason).toContain("more than");
+  });
+
+  it("rejects a string value longer than the cap", () => {
+    const long = "x".repeat(SHARED_CONFIG_LIMITS.maxStringLength + 1);
+    const result = validateSharedConfig({ "font-family": long });
+    expect(result.config).toEqual({});
+  });
+
+  it("returns a fresh object with no prototype links", () => {
+    const result = validateSharedConfig({ "font-family": "JetBrains Mono" });
+    // Object.create(null) makes this falsy - which is what we want.
+    expect(Object.getPrototypeOf(result.config)).toBeNull();
+  });
+
+  it("accepts a valid duration", () => {
+    const result = validateSharedConfig({ "resize-overlay-duration": "750ms" });
+    expect(result.config).toEqual({ "resize-overlay-duration": "750ms" });
+  });
+
+  it("accepts a composite duration", () => {
+    const result = validateSharedConfig({
+      "resize-overlay-duration": "1h30m",
+    });
+    expect(result.config).toEqual({ "resize-overlay-duration": "1h30m" });
+  });
+
+  it("rejects a duration with no unit", () => {
+    const result = validateSharedConfig({
+      "resize-overlay-duration": "100",
+    });
+    expect(result.config).toEqual({});
+  });
+
+  it("rejects a duration with a decimal part", () => {
+    const result = validateSharedConfig({
+      "resize-overlay-duration": "1.5s",
+    });
+    expect(result.config).toEqual({});
+  });
+
+  it("accepts '0' as a duration (a bare zero is valid in Ghostty)", () => {
+    const result = validateSharedConfig({ "resize-overlay-duration": "0" });
+    expect(result.config).toEqual({ "resize-overlay-duration": "0" });
+  });
+});
+
+describe("validateSharedThemeName", () => {
+  it("accepts a normal theme name", () => {
+    expect(validateSharedThemeName("Tokyo Night")).toBe("Tokyo Night");
+  });
+
+  it("returns null for non-strings", () => {
+    expect(validateSharedThemeName(null)).toBeNull();
+    expect(validateSharedThemeName(undefined)).toBeNull();
+    expect(validateSharedThemeName(42)).toBeNull();
+  });
+
+  it("returns null for the empty string", () => {
+    expect(validateSharedThemeName("")).toBeNull();
+  });
+
+  it("returns null when the name is too long", () => {
+    const tooLong = "x".repeat(SHARED_CONFIG_LIMITS.maxThemeNameLength + 1);
+    expect(validateSharedThemeName(tooLong)).toBeNull();
+  });
+
+  it("rejects control characters", () => {
+    expect(validateSharedThemeName("evil\nname")).toBeNull();
+    expect(validateSharedThemeName("evil\rname")).toBeNull();
+    expect(validateSharedThemeName("evil\tname")).toBeNull();
+  });
+
+  it("rejects characters that could break out of a quoted comment", () => {
+    expect(validateSharedThemeName('"quoted"')).toBeNull();
+    expect(validateSharedThemeName("with\\back")).toBeNull();
+  });
+});

--- a/src/lib/security/validate-shared-config.ts
+++ b/src/lib/security/validate-shared-config.ts
@@ -1,0 +1,267 @@
+// Runtime shape validation for decoded share URLs.
+//
+// `decodeConfig` in url-share.ts takes an LZString payload, runs JSON.parse
+// on it, and returns the result typed as `ShareableConfig`. That trust
+// boundary is the main XSS / prototype-pollution / DoS surface for the
+// "shared configuration" feature: a crafted URL can hand us an object of
+// arbitrary shape, and we later feed it into the Zustand store which
+// re-renders every value via the input widgets.
+//
+// Today the widgets all coerce values to primitives on render (React
+// escapes strings, numbers are formatted, switches/selects only accept
+// well-defined unions), so a malicious payload does not directly produce
+// HTML injection. But that's a property of the consumer, not the data
+// format. This module enforces the shape explicitly so a future widget
+// refactor can't accidentally widen the trust boundary.
+
+import type { ConfigOption } from "@/lib/schema/types";
+import { allOptions } from "@/data/ghostty-options";
+
+/** Hard caps applied during validation. Generous enough for any realistic
+ *  hand-crafted config, small enough to bound memory and render cost. */
+export const SHARED_CONFIG_LIMITS = {
+  maxKeys: 500,
+  maxStringLength: 8192,
+  maxArrayLength: 1024,
+  maxThemeNameLength: 256,
+} as const;
+
+const HEX_COLOR_PATTERN = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
+const X11_NAME_PATTERN = /^[a-z][a-z0-9 _-]*$/i;
+
+type ValidatedKey =
+  | { kind: "ok"; key: string }
+  | { kind: "drop"; key: string; reason: string };
+
+interface ValidationContext {
+  knownOptionsById: Map<string, ConfigOption>;
+}
+
+/**
+ * Validate a raw value for a known config key. Returns the cleaned value,
+ * or `null` if the value cannot be coerced into the expected shape and
+ * should be dropped from the shared config.
+ */
+function validateValueForOption(
+  option: ConfigOption,
+  rawValue: unknown
+): unknown | null {
+  switch (option.type) {
+    case "string":
+      return validateStringValue(rawValue);
+
+    case "number": {
+      const n = coerceFiniteNumber(rawValue);
+      return n === null ? null : n;
+    }
+
+    case "boolean":
+      if (typeof rawValue === "boolean") return rawValue;
+      if (rawValue === "true") return true;
+      if (rawValue === "false") return false;
+      return null;
+
+    case "enum":
+      if (typeof rawValue !== "string") return null;
+      if (!option.options.some((o) => o.value === rawValue)) return null;
+      return rawValue;
+
+    case "color":
+      if (typeof rawValue !== "string") return null;
+      return validateColorValue(rawValue) ? rawValue : null;
+
+    case "palette":
+      return validateStringArray(rawValue, (entry) =>
+        validatePaletteEntry(entry)
+      );
+
+    case "keybind":
+      return validateStringArray(rawValue, (entry) =>
+        validateKeybindEntry(entry)
+      );
+
+    case "duration":
+      if (typeof rawValue !== "string") return null;
+      return validateDurationValue(rawValue) ? rawValue : null;
+
+    default:
+      // Exhaustiveness check - if a new option type is added without
+      // updating this switch, TypeScript will fail to compile.
+      return null;
+  }
+}
+
+function validateStringValue(rawValue: unknown): string | null {
+  if (typeof rawValue !== "string") return null;
+  if (rawValue.length > SHARED_CONFIG_LIMITS.maxStringLength) return null;
+  return rawValue;
+}
+
+function coerceFiniteNumber(rawValue: unknown): number | null {
+  if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+    return rawValue;
+  }
+  if (typeof rawValue === "string") {
+    const parsed = Number(rawValue);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function validateColorValue(value: string): boolean {
+  if (value.length > SHARED_CONFIG_LIMITS.maxStringLength) return false;
+  if (HEX_COLOR_PATTERN.test(value)) return true;
+  return X11_NAME_PATTERN.test(value);
+}
+
+function validateDurationValue(value: string): boolean {
+  if (value.length > SHARED_CONFIG_LIMITS.maxStringLength) return false;
+  if (value === "0") return true;
+  // Match a sequence of `N{unit}` parts separated by whitespace. Mirrors
+  // the rules in lib/utils/config-validation.ts so a value the editor
+  // would accept is also a value the share loader accepts.
+  return /^(\d+(y|w|d|h|m|s|ms|us|µs|ns)\s*)+$/.test(value);
+}
+
+function validateStringArray(
+  rawValue: unknown,
+  validateEntry: (entry: string) => boolean
+): string[] | null {
+  let entries: unknown[];
+
+  if (Array.isArray(rawValue)) {
+    entries = rawValue;
+  } else if (typeof rawValue === "string") {
+    // Allow a single string to be promoted to a one-element array. This
+    // matches how `parseGhosttyConfig` accepts a single repeatable value.
+    entries = [rawValue];
+  } else {
+    return null;
+  }
+
+  if (entries.length > SHARED_CONFIG_LIMITS.maxArrayLength) return null;
+
+  const cleaned: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry !== "string") return null;
+    if (entry.length > SHARED_CONFIG_LIMITS.maxStringLength) return null;
+    if (!validateEntry(entry)) return null;
+    cleaned.push(entry);
+  }
+
+  return cleaned;
+}
+
+function validatePaletteEntry(entry: string): boolean {
+  // Ghostty accepts decimal, hex (0x), octal (0o), or binary (0b)
+  // indices. The downstream `parsePaletteEntry` already validates this;
+  // we just enforce a coarse shape so a garbage share URL doesn't
+  // pollute the store before it reaches the editor.
+  return /^(0|[1-9][0-9]*|0x[0-9a-f]+|0o[0-7]+|0b[01]+)=.+$/i.test(entry);
+}
+
+function validateKeybindEntry(entry: string): boolean {
+  // A keybind is `trigger=action`. Don't try to fully parse the trigger
+  // / action grammar here - the editor's own validator will surface
+  // problems at the row level, and we don't want to reject legacy or
+  // future-compatible forms. We just enforce the basic split.
+  const eq = entry.indexOf("=");
+  if (eq <= 0 || eq === entry.length - 1) return false;
+  return entry.length <= SHARED_CONFIG_LIMITS.maxStringLength;
+}
+
+function validateKey(
+  key: string,
+  ctx: ValidationContext
+): ValidatedKey {
+  if (typeof key !== "string") {
+    return { kind: "drop", key: String(key), reason: "non-string key" };
+  }
+  if (key.length > 256) {
+    return { kind: "drop", key, reason: "key too long" };
+  }
+  // Reject anything that could touch the prototype chain or be a
+  // constructor lookup. Config keys are always kebab-case ASCII.
+  if (key === "__proto__" || key === "constructor" || key === "prototype") {
+    return { kind: "drop", key, reason: "forbidden key" };
+  }
+  if (!ctx.knownOptionsById.has(key)) {
+    return { kind: "drop", key, reason: "unknown option" };
+  }
+  return { kind: "ok", key };
+}
+
+/**
+ * Validate and clean a decoded `ConfigValues`-shaped object.
+ *
+ * - Unknown keys are dropped (the store is the source of truth for which
+ *   options exist; we don't want a share URL to seed keys the editor
+ *   doesn't know how to render).
+ * - Values that don't match the option's expected shape are dropped.
+ * - All drops are recorded in `dropped` so the caller can surface them in
+ *   the share-page UI if desired.
+ *
+ * The cleaned object is a fresh, plain object with no prototype links.
+ */
+export function validateSharedConfig(
+  rawConfig: unknown
+): {
+  config: Record<string, unknown>;
+  dropped: Array<{ key: string; reason: string }>;
+} {
+  const ctx: ValidationContext = {
+    knownOptionsById: new Map(allOptions.map((o) => [o.id, o])),
+  };
+
+  if (rawConfig === null || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+    return { config: {}, dropped: [{ key: "<root>", reason: "config must be an object" }] };
+  }
+
+  const entries = Object.entries(rawConfig as Record<string, unknown>);
+  if (entries.length > SHARED_CONFIG_LIMITS.maxKeys) {
+    return {
+      config: {},
+      dropped: [{ key: "<root>", reason: `more than ${SHARED_CONFIG_LIMITS.maxKeys} keys` }],
+    };
+  }
+
+  const config: Record<string, unknown> = Object.create(null);
+  const dropped: Array<{ key: string; reason: string }> = [];
+
+  for (const [rawKey, rawValue] of entries) {
+    const keyResult = validateKey(rawKey, ctx);
+    if (keyResult.kind === "drop") {
+      dropped.push({ key: keyResult.key, reason: keyResult.reason });
+      continue;
+    }
+
+    const option = ctx.knownOptionsById.get(keyResult.key)!;
+    const cleaned = validateValueForOption(option, rawValue);
+    if (cleaned === null) {
+      dropped.push({ key: keyResult.key, reason: "invalid value shape" });
+      continue;
+    }
+
+    config[keyResult.key] = cleaned;
+  }
+
+  return { config, dropped };
+}
+
+/**
+ * Validate a theme name embedded in a share URL. The theme name is
+ * rendered as text in the share page (safe), but it's also passed to the
+ * config store and shown in the exported config comment, so we still
+ * want to bound its length and reject control characters.
+ */
+export function validateSharedThemeName(rawTheme: unknown): string | null {
+  if (typeof rawTheme !== "string") return null;
+  if (rawTheme.length === 0) return null;
+  if (rawTheme.length > SHARED_CONFIG_LIMITS.maxThemeNameLength) return null;
+  // Disallow control characters and any character that could break out
+  // of a quoted config comment. The exported theme comment is on its
+  // own line so the risk is low, but the constraint is essentially
+  // free.
+  if (/[\x00-\x1f\x7f"\\]/.test(rawTheme)) return null;
+  return rawTheme;
+}

--- a/src/lib/security/validate-shared-config.ts
+++ b/src/lib/security/validate-shared-config.ts
@@ -16,6 +16,7 @@
 
 import type { ConfigOption } from "@/lib/schema/types";
 import { allOptions } from "@/data/ghostty-options";
+import { validateConfigValue } from "@/lib/utils/config-validation";
 
 /** Hard caps applied during validation. Generous enough for any realistic
  *  hand-crafted config, small enough to bound memory and render cost. */
@@ -25,9 +26,6 @@ export const SHARED_CONFIG_LIMITS = {
   maxArrayLength: 1024,
   maxThemeNameLength: 256,
 } as const;
-
-const HEX_COLOR_PATTERN = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
-const X11_NAME_PATTERN = /^[a-z][a-z0-9 _-]*$/i;
 
 type ValidatedKey =
   | { kind: "ok"; key: string }
@@ -48,12 +46,12 @@ function validateValueForOption(
 ): unknown | null {
   switch (option.type) {
     case "string":
-      return validateStringValue(rawValue);
+      return option.repeatable
+        ? validateRepeatableStringValue(rawValue)
+        : validateStringValue(rawValue);
 
-    case "number": {
-      const n = coerceFiniteNumber(rawValue);
-      return n === null ? null : n;
-    }
+    case "number":
+      return validateValueUsingEditorRules(option, rawValue);
 
     case "boolean":
       if (typeof rawValue === "boolean") return rawValue;
@@ -67,8 +65,7 @@ function validateValueForOption(
       return rawValue;
 
     case "color":
-      if (typeof rawValue !== "string") return null;
-      return validateColorValue(rawValue) ? rawValue : null;
+      return validateValueUsingEditorRules(option, rawValue);
 
     case "palette":
       return validateStringArray(rawValue, (entry) =>
@@ -81,8 +78,7 @@ function validateValueForOption(
       );
 
     case "duration":
-      if (typeof rawValue !== "string") return null;
-      return validateDurationValue(rawValue) ? rawValue : null;
+      return validateValueUsingEditorRules(option, rawValue);
 
     default:
       // Exhaustiveness check - if a new option type is added without
@@ -97,30 +93,36 @@ function validateStringValue(rawValue: unknown): string | null {
   return rawValue;
 }
 
-function coerceFiniteNumber(rawValue: unknown): number | null {
-  if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
-    return rawValue;
-  }
+function validateRepeatableStringValue(rawValue: unknown): string | string[] | null {
   if (typeof rawValue === "string") {
-    const parsed = Number(rawValue);
-    if (Number.isFinite(parsed)) return parsed;
+    return validateStringValue(rawValue);
   }
-  return null;
+
+  if (!Array.isArray(rawValue)) return null;
+  if (rawValue.length > SHARED_CONFIG_LIMITS.maxArrayLength) return null;
+
+  const cleaned: string[] = [];
+  for (const entry of rawValue) {
+    const cleanedEntry = validateStringValue(entry);
+    if (cleanedEntry === null) return null;
+    cleaned.push(cleanedEntry);
+  }
+
+  return cleaned;
 }
 
-function validateColorValue(value: string): boolean {
-  if (value.length > SHARED_CONFIG_LIMITS.maxStringLength) return false;
-  if (HEX_COLOR_PATTERN.test(value)) return true;
-  return X11_NAME_PATTERN.test(value);
-}
+function validateValueUsingEditorRules(
+  option: ConfigOption,
+  rawValue: unknown
+): unknown | null {
+  if (typeof rawValue === "string" && rawValue.length > SHARED_CONFIG_LIMITS.maxStringLength) {
+    return null;
+  }
 
-function validateDurationValue(value: string): boolean {
-  if (value.length > SHARED_CONFIG_LIMITS.maxStringLength) return false;
-  if (value === "0") return true;
-  // Match a sequence of `N{unit}` parts separated by whitespace. Mirrors
-  // the rules in lib/utils/config-validation.ts so a value the editor
-  // would accept is also a value the share loader accepts.
-  return /^(\d+(y|w|d|h|m|s|ms|us|µs|ns)\s*)+$/.test(value);
+  const validation = validateConfigValue(option, rawValue);
+  if (!validation.valid) return null;
+
+  return validation.normalizedValue ?? rawValue;
 }
 
 function validateStringArray(
@@ -161,6 +163,9 @@ function validatePaletteEntry(entry: string): boolean {
 }
 
 function validateKeybindEntry(entry: string): boolean {
+  // Ghostty also accepts `keybind = clear` to clear all default bindings.
+  if (entry === "clear") return true;
+
   // A keybind is `trigger=action`. Don't try to fully parse the trigger
   // / action grammar here - the editor's own validator will surface
   // problems at the row level, and we don't want to reject legacy or

--- a/src/lib/utils/themes.test.ts
+++ b/src/lib/utils/themes.test.ts
@@ -239,6 +239,29 @@ describe('theme fetch hardening', () => {
       ]);
     });
 
+    it('accepts a valid GitHub API list larger than the individual theme-file cap', async () => {
+      const entries = Array.from({ length: 3000 }, (_, index) => ({
+        type: 'file',
+        name: `Theme ${index.toString().padStart(4, '0')}`,
+        download_url: `https://example.test/theme-${index.toString().padStart(4, '0')}`,
+        path: `ghostty/theme-${index.toString().padStart(4, '0')}`,
+        sha: 'a'.repeat(40),
+      }));
+      const payload = JSON.stringify(entries);
+      expect(new TextEncoder().encode(payload).byteLength).toBeGreaterThan(256 * 1024);
+
+      fetchSpy.mockResolvedValue(
+        new Response(payload, { headers: { 'content-type': 'application/json' } })
+      );
+
+      const list = await fetchThemeList();
+      expect(list).toHaveLength(3000);
+      expect(list[0]).toEqual({
+        name: 'Theme 0000',
+        downloadUrl: 'https://example.test/theme-0000',
+      });
+    });
+
     it('rejects when the JSON content-type is wrong', async () => {
       fetchSpy.mockResolvedValue(
         new Response('not json', { headers: { 'content-type': 'text/html' } })

--- a/src/lib/utils/themes.test.ts
+++ b/src/lib/utils/themes.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   parseThemeContent,
   themeToConfig,
   categorizeTheme,
   FEATURED_THEMES,
+  ensureTextResponse,
+  readBoundedText,
+  fetchThemeList,
+  fetchTheme,
 } from '@/lib/utils/themes';
 
 describe('themes', () => {
@@ -45,254 +49,267 @@ selection-foreground = #ffffff
 
     it('should parse palette entries', () => {
       const content = `
-palette = 0=#15161e
-palette = 1=#f7768e
-palette = 2=#9ece6a
-palette = 15=#c0caf5
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.palette[0]).toBe('#15161e');
-      expect(colors.palette[1]).toBe('#f7768e');
-      expect(colors.palette[2]).toBe('#9ece6a');
-      expect(colors.palette[15]).toBe('#c0caf5');
-    });
-
-    it('should handle palette entries without # prefix', () => {
-      const content = `
-palette = 0=15161e
-palette = 1=f7768e
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.palette[0]).toBe('#15161e');
-      expect(colors.palette[1]).toBe('#f7768e');
-    });
-
-    it('should parse non-decimal palette indexes from Ghostty syntax', () => {
-      const content = `
-palette = 0b10=111111
-palette = 0o10=222222
-palette = 0xF=333333
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.palette[2]).toBe('#111111');
-      expect(colors.palette[8]).toBe('#222222');
-      expect(colors.palette[15]).toBe('#333333');
-    });
-
-    it('should skip comments', () => {
-      const content = `
-# This is a comment
-background = #1a1b26
-# Another comment
-foreground = #c0caf5
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.background).toBe('#1a1b26');
-      expect(colors.foreground).toBe('#c0caf5');
-    });
-
-    it('should skip empty lines', () => {
-      const content = `
-
-background = #1a1b26
-
-foreground = #c0caf5
-
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.background).toBe('#1a1b26');
-      expect(colors.foreground).toBe('#c0caf5');
-    });
-
-    it('should ignore invalid palette entries', () => {
-      const content = `
-palette = not_valid
-palette = 0=#15161e
-palette = invalid_index=abc
-`;
-      const colors = parseThemeContent(content);
-
-      expect(colors.palette[0]).toBe('#15161e');
-    });
-
-    it('should ignore palette entries with out-of-range index', () => {
-      const content = `
 palette = 0=#000000
-palette = 16=#ffffff
-palette = -1=#ff0000
+palette = 1=#ff0000
+palette = 15=#ffffff
 `;
       const colors = parseThemeContent(content);
 
       expect(colors.palette[0]).toBe('#000000');
-      expect(colors.palette[16]).toBeUndefined();
-      expect(colors.palette[15]).toBe(''); // default empty
-    });
-
-    it('should have empty palette array by default', () => {
-      const colors = parseThemeContent('');
-      
-      expect(colors.palette).toHaveLength(16);
-      expect(colors.palette.every(c => c === '')).toBe(true);
-    });
-
-    it('should default background and foreground', () => {
-      const colors = parseThemeContent('');
-      
-      expect(colors.background).toBe('#000000');
-      expect(colors.foreground).toBe('#ffffff');
+      expect(colors.palette[1]).toBe('#ff0000');
+      expect(colors.palette[15]).toBe('#ffffff');
     });
   });
 
   describe('themeToConfig', () => {
-    it('should convert theme colors to config object', () => {
+    it('should convert theme colors to config format', () => {
       const theme = {
-        name: 'Test Theme',
-        colors: {
-          background: '#1a1b26',
-          foreground: '#c0caf5',
-          cursorColor: '#ffffff',
-          palette: ['#15161e', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '#c0caf5'],
-          raw: '',
-        },
+        name: 'Test',
         raw: '',
-      };
-
-      const config = themeToConfig(theme);
-
-      expect(config['background']).toBe('#1a1b26');
-      expect(config['foreground']).toBe('#c0caf5');
-      expect(config['cursor-color']).toBe('#ffffff');
-    });
-
-    it('should not include undefined colors', () => {
-      const theme = {
-        name: 'Minimal Theme',
-        colors: {
-          background: '#1a1b26',
-          foreground: '#c0caf5',
-          palette: ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ''],
-          raw: '',
-        },
-        raw: '',
-      };
-
-      const config = themeToConfig(theme);
-
-      expect(config['cursor-color']).toBeUndefined();
-      expect(config['selection-background']).toBeUndefined();
-    });
-
-    it('should convert palette to config entries', () => {
-      const theme = {
-        name: 'Theme With Palette',
         colors: {
           background: '#000000',
           foreground: '#ffffff',
-          palette: [
-            '#000000', '#ff0000', '#00ff00', '#0000ff',
-            '#ffff00', '#ff00ff', '#00ffff', '#ffffff',
-            '#808080', '#c0c0c0', '#404040', '#a0a0a0',
-            '#202020', '#606060', '#e0e0e0', '#ffffff',
-          ],
-          raw: '',
+          cursorColor: '#ff0000',
+          palette: ['#111111', '#222222', '', '', '', '', '', '',
+            '', '', '', '', '', '', '', ''],
         },
-        raw: '',
       };
 
       const config = themeToConfig(theme);
-
-      expect(config['palette']).toContain('0=#000000');
-      expect(config['palette']).toContain('1=#ff0000');
-      expect(config['palette']).toContain('15=#ffffff');
+      expect(config.background).toBe('#000000');
+      expect(config.foreground).toBe('#ffffff');
+      expect(config['cursor-color']).toBe('#ff0000');
+      expect(config.palette).toEqual(['0=#111111', '1=#222222']);
     });
 
-    it('should filter out empty palette entries', () => {
+    it('should omit palette when no colors are set', () => {
       const theme = {
-        name: 'Partial Palette',
+        name: 'Empty',
+        raw: '',
         colors: {
           background: '#000000',
           foreground: '#ffffff',
-          palette: ['', '', '#ff0000', '', '', '', '', '', '', '', '', '', '', '', '', ''],
-          raw: '',
+          palette: Array(16).fill(''),
         },
-        raw: '',
       };
 
       const config = themeToConfig(theme);
-
-      expect(config['palette']).toEqual(['2=#ff0000']);
+      expect(config.palette).toBeUndefined();
     });
   });
 
   describe('categorizeTheme', () => {
-    it('should categorize dark theme (low luminance)', () => {
-      const theme = {
-        name: 'Dark Theme',
-        colors: {
-          background: '#1a1b26',
-          foreground: '#c0caf5',
-          palette: [],
-          raw: '',
-        },
+    it('should categorize dark themes', () => {
+      const dark = {
+        name: 'Dark',
         raw: '',
+        colors: { background: '#000000', foreground: '#ffffff', palette: [] },
       };
-
-      expect(categorizeTheme(theme)).toBe('dark');
+      expect(categorizeTheme(dark)).toBe('dark');
     });
 
-    it('should categorize light theme (high luminance)', () => {
-      const theme = {
-        name: 'Light Theme',
-        colors: {
-          background: '#ffffff',
-          foreground: '#000000',
-          palette: [],
-          raw: '',
-        },
+    it('should categorize light themes', () => {
+      const light = {
+        name: 'Light',
         raw: '',
+        colors: { background: '#ffffff', foreground: '#000000', palette: [] },
       };
-
-      expect(categorizeTheme(theme)).toBe('light');
-    });
-
-    it('should handle mid-tone backgrounds', () => {
-      // Background with ~50% luminance should be light
-      const theme = {
-        name: 'Mid Theme',
-        colors: {
-          background: '#808080', // 50% luminance
-          foreground: '#000000',
-          palette: [],
-          raw: '',
-        },
-        raw: '',
-      };
-
-      // 0.299*128 + 0.587*128 + 0.114*128 = 128 which is exactly 0.5
-      // The function returns "light" for > 0.5, so 0.5 exactly is light
-      expect(categorizeTheme(theme)).toBe('light');
+      expect(categorizeTheme(light)).toBe('light');
     });
   });
 
   describe('FEATURED_THEMES', () => {
-    it('should contain expected popular themes', () => {
-      expect(FEATURED_THEMES).toContain('Dracula');
-      expect(FEATURED_THEMES).toContain('Tokyo Night');
-      expect(FEATURED_THEMES).toContain('Nord');
+    it('should be a non-empty array of strings', () => {
+      expect(Array.isArray(FEATURED_THEMES)).toBe(true);
+      expect(FEATURED_THEMES.length).toBeGreaterThan(0);
+      FEATURED_THEMES.forEach((name) => {
+        expect(typeof name).toBe('string');
+        expect(name.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});
+
+describe('theme fetch hardening', () => {
+  describe('ensureTextResponse', () => {
+    it('accepts a response whose content-type starts with the expected prefix', () => {
+      const response = new Response('hello', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+      expect(() => ensureTextResponse(response, 'text/', 'test')).not.toThrow();
     });
 
-    it('should not have duplicates', () => {
-      const unique = new Set(FEATURED_THEMES);
-      expect(unique.size).toBe(FEATURED_THEMES.length);
+    it('is case-insensitive on the content-type', () => {
+      const response = new Response('hello', {
+        headers: { 'content-type': 'Text/Plain' },
+      });
+      expect(() => ensureTextResponse(response, 'text/', 'test')).not.toThrow();
     });
 
-    it('should be an array with at least 10 themes', () => {
-      expect(FEATURED_THEMES.length).toBeGreaterThanOrEqual(10);
+    it('throws when the content-type does not match', () => {
+      const response = new Response('hello', {
+        headers: { 'content-type': 'application/octet-stream' },
+      });
+      expect(() => ensureTextResponse(response, 'text/', 'theme "X"'))
+        .toThrow(/Unexpected content-type/);
+    });
+
+    it('throws when the content-type header is missing', () => {
+      // The Response constructor auto-adds `content-type: text/plain`
+      // for string bodies, so we delete it explicitly to exercise the
+      // missing-header fallback in the production code.
+      const response = new Response('hello');
+      response.headers.delete('content-type');
+      expect(() => ensureTextResponse(response, 'text/', 'theme "X"'))
+        .toThrow(/Unexpected content-type/);
+    });
+  });
+
+  describe('readBoundedText', () => {
+    it('reads a small text body correctly', async () => {
+      const response = new Response('hello world', {
+        headers: { 'content-type': 'text/plain' },
+      });
+      const text = await readBoundedText(response, 'test');
+      expect(text).toBe('hello world');
+    });
+
+    it('throws when the body exceeds the 256 KB cap', async () => {
+      // Build a 300 KB body across multiple chunks so the streaming
+      // reader's per-chuck accounting is exercised, not just a single
+      // massive buffer.
+      const big = new Uint8Array(300 * 1024).fill(0x41); // 300 KB of 'A'
+      const stream = new ReadableStream({
+        start(controller) {
+          // Split into 16 chunks of ~18 KB so the read loop runs many
+          // iterations.
+          const chunkSize = 18 * 1024;
+          for (let offset = 0; offset < big.byteLength; offset += chunkSize) {
+            controller.enqueue(big.slice(offset, offset + chunkSize));
+          }
+          controller.close();
+        },
+      });
+      const response = new Response(stream, {
+        headers: { 'content-type': 'text/plain' },
+      });
+
+      await expect(readBoundedText(response, 'test'))
+        .rejects.toThrow(/exceeded 262144 bytes/);
+    });
+
+    it('falls back to response.text() when the body stream is unavailable', async () => {
+      // A Response constructed from a string is fine, but a Response
+      // with `body: null` only happens for certain edge cases (e.g.
+      // a no-content status). We construct it explicitly to make sure
+      // the fallback path also reads the body correctly.
+      const response = new Response(null, { status: 204 });
+      const text = await readBoundedText(response, 'test');
+      expect(text).toBe('');
+    });
+  });
+
+  describe('fetchThemeList', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('returns the file entries when the GitHub API responds with an array', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            { type: 'file', name: 'Dracula', download_url: 'https://example/dracula' },
+            { type: 'dir', name: 'subfolder', download_url: '' },
+            { type: 'file', name: 'Nord', download_url: 'https://example/nord' },
+          ]),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      );
+
+      const list = await fetchThemeList();
+      expect(list).toEqual([
+        { name: 'Dracula', downloadUrl: 'https://example/dracula' },
+        { name: 'Nord', downloadUrl: 'https://example/nord' },
+      ]);
+    });
+
+    it('rejects when the JSON content-type is wrong', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response('not json', { headers: { 'content-type': 'text/html' } })
+      );
+
+      await expect(fetchThemeList()).rejects.toThrow(/Unexpected content-type/);
+    });
+
+    it('rejects when the body is valid JSON but not an array', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response(JSON.stringify({ message: 'rate limited' }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+      await expect(fetchThemeList()).rejects.toThrow(
+        /Unexpected theme list response shape/
+      );
+    });
+  });
+
+  describe('fetchTheme', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('returns a parsed theme for a valid response', async () => {
+      const theme = 'background = #1a1b26\nforeground = #c0caf5\n';
+      fetchSpy.mockResolvedValue(
+        new Response(theme, { headers: { 'content-type': 'text/plain' } })
+      );
+
+      const result = await fetchTheme('Tokyo Night');
+      expect(result.colors.background).toBe('#1a1b26');
+      expect(result.colors.foreground).toBe('#c0caf5');
+      expect(result.raw).toBe(theme);
+    });
+
+    it('rejects when the content-type is not text', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response('background = #000', {
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+      );
+
+      await expect(fetchTheme('Whatever')).rejects.toThrow(/Unexpected content-type/);
+    });
+
+    it('rejects a theme body larger than the 256 KB cap', async () => {
+      const huge = '# ' + 'a'.repeat(300 * 1024) + '\n';
+      const stream = new ReadableStream({
+        start(controller) {
+          const chunkSize = 32 * 1024;
+          const bytes = new TextEncoder().encode(huge);
+          for (let offset = 0; offset < bytes.byteLength; offset += chunkSize) {
+            controller.enqueue(bytes.slice(offset, offset + chunkSize));
+          }
+          controller.close();
+        },
+      });
+      fetchSpy.mockResolvedValue(
+        new Response(stream, { headers: { 'content-type': 'text/plain' } })
+      );
+
+      await expect(fetchTheme('Huge')).rejects.toThrow(/exceeded 262144 bytes/);
     });
   });
 });

--- a/src/lib/utils/themes.ts
+++ b/src/lib/utils/themes.ts
@@ -20,8 +20,10 @@ const MAX_THEME_BYTES = 256 * 1024;
  * upstream could send HTML / JSON / binary, and our `key = value` line
  * parser would either silently accept garbled values or error in
  * unhelpful ways.
+ *
+ * @internal Exported for unit tests; not part of the public API.
  */
-function ensureTextResponse(
+export function ensureTextResponse(
   response: Response,
   expectedPrefix: string,
   context: string
@@ -39,8 +41,10 @@ function ensureTextResponse(
  * if the body is larger than `MAX_THEME_BYTES`. We stream the response
  * so we can abort as soon as the cap is exceeded rather than waiting
  * for the full body to download.
+ *
+ * @internal Exported for unit tests; not part of the public API.
  */
-async function readBoundedText(
+export async function readBoundedText(
   response: Response,
   context: string
 ): Promise<string> {
@@ -165,6 +169,13 @@ export async function fetchThemeList(): Promise<ThemeListItem[]> {
     name: string;
     download_url: string;
   }>;
+
+  // A misconfigured upstream could return `{}` (e.g. an error payload
+  // with a JSON content-type). Surface that as a hard error instead of
+  // silently producing an empty theme list.
+  if (!Array.isArray(data)) {
+    throw new Error("Unexpected theme list response shape from GitHub");
+  }
 
   return data
     .filter((item) => item.type === "file")

--- a/src/lib/utils/themes.ts
+++ b/src/lib/utils/themes.ts
@@ -13,6 +13,7 @@ const RAW_CONTENT_BASE = "https://raw.githubusercontent.com/mbadolato/iTerm2-Col
  * exceeded, so the cost is bounded regardless of upstream behaviour.
  */
 const MAX_THEME_BYTES = 256 * 1024;
+const MAX_THEME_LIST_BYTES = 2 * 1024 * 1024;
 
 /**
  * Asserts that a fetch response is a textual payload before we hand it
@@ -46,7 +47,8 @@ export function ensureTextResponse(
  */
 export async function readBoundedText(
   response: Response,
-  context: string
+  context: string,
+  maxBytes = MAX_THEME_BYTES
 ): Promise<string> {
   if (!response.body) {
     return response.text();
@@ -61,10 +63,10 @@ export async function readBoundedText(
     const { value, done } = await reader.read();
     if (done) break;
     received += value.byteLength;
-    if (received > MAX_THEME_BYTES) {
+    if (received > maxBytes) {
       try { await reader.cancel(); } catch { /* noop */ }
       throw new Error(
-        `Theme payload exceeded ${MAX_THEME_BYTES} bytes while fetching ${context}`
+        `Theme payload exceeded ${maxBytes} bytes while fetching ${context}`
       );
     }
     text += decoder.decode(value, { stream: true });
@@ -164,7 +166,7 @@ export async function fetchThemeList(): Promise<ThemeListItem[]> {
   // The theme list is small (a few hundred entries) but we still cap it
   // defensively in case a future migration brings the list to a different
   // host with looser limits.
-  const data = JSON.parse(await readBoundedText(response, "theme list")) as Array<{
+  const data = JSON.parse(await readBoundedText(response, "theme list", MAX_THEME_LIST_BYTES)) as Array<{
     type: string;
     name: string;
     download_url: string;

--- a/src/lib/utils/themes.ts
+++ b/src/lib/utils/themes.ts
@@ -5,6 +5,71 @@ import { parsePaletteEntry } from "@/lib/utils/palette";
 const GITHUB_API_BASE = "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
 const RAW_CONTENT_BASE = "https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/ghostty";
 
+/**
+ * Hard cap on theme payload size. A real Ghostty theme file is well under
+ * 10 KB; 256 KB leaves generous headroom for future expansion while
+ * preventing a hostile origin from streaming gigabytes into the browser
+ * and forcing the parser to OOM. Fetch is aborted as soon as the cap is
+ * exceeded, so the cost is bounded regardless of upstream behaviour.
+ */
+const MAX_THEME_BYTES = 256 * 1024;
+
+/**
+ * Asserts that a fetch response is a textual payload before we hand it
+ * to the parser. Without this, a misconfigured proxy or a compromised
+ * upstream could send HTML / JSON / binary, and our `key = value` line
+ * parser would either silently accept garbled values or error in
+ * unhelpful ways.
+ */
+function ensureTextResponse(
+  response: Response,
+  expectedPrefix: string,
+  context: string
+): void {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith(expectedPrefix)) {
+    throw new Error(
+      `Unexpected content-type "${contentType}" while fetching ${context}`
+    );
+  }
+}
+
+/**
+ * Read a fetch response body as text, enforcing a hard byte cap. Throws
+ * if the body is larger than `MAX_THEME_BYTES`. We stream the response
+ * so we can abort as soon as the cap is exceeded rather than waiting
+ * for the full body to download.
+ */
+async function readBoundedText(
+  response: Response,
+  context: string
+): Promise<string> {
+  if (!response.body) {
+    return response.text();
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let received = 0;
+  let text = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > MAX_THEME_BYTES) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      throw new Error(
+        `Theme payload exceeded ${MAX_THEME_BYTES} bytes while fetching ${context}`
+      );
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+
+  text += decoder.decode();
+  return text;
+}
+
 export interface ThemeColors {
   background: string;
   foreground: string;
@@ -90,11 +155,20 @@ export async function fetchThemeList(): Promise<ThemeListItem[]> {
     throw new Error(`Failed to fetch theme list: ${response.statusText}`);
   }
 
-  const data = await response.json();
-  
+  ensureTextResponse(response, "application/json", "theme list");
+
+  // The theme list is small (a few hundred entries) but we still cap it
+  // defensively in case a future migration brings the list to a different
+  // host with looser limits.
+  const data = JSON.parse(await readBoundedText(response, "theme list")) as Array<{
+    type: string;
+    name: string;
+    download_url: string;
+  }>;
+
   return data
-    .filter((item: { type: string }) => item.type === "file")
-    .map((item: { name: string; download_url: string }) => ({
+    .filter((item) => item.type === "file")
+    .map((item) => ({
       name: item.name,
       downloadUrl: item.download_url,
     }));
@@ -104,7 +178,7 @@ export async function fetchThemeList(): Promise<ThemeListItem[]> {
 export async function fetchTheme(name: string): Promise<Theme> {
   const encodedName = encodeURIComponent(name);
   const url = `${RAW_CONTENT_BASE}/${encodedName}`;
-  
+
   const response = await fetch(url, {
     next: { revalidate: 86400 }, // Cache for 24 hours
   });
@@ -113,7 +187,9 @@ export async function fetchTheme(name: string): Promise<Theme> {
     throw new Error(`Failed to fetch theme "${name}": ${response.statusText}`);
   }
 
-  const content = await response.text();
+  ensureTextResponse(response, "text/", `theme "${name}"`);
+
+  const content = await readBoundedText(response, `theme "${name}"`);
   const colors = parseThemeContent(content);
 
   return {

--- a/src/lib/utils/url-share.test.ts
+++ b/src/lib/utils/url-share.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import LZString from 'lz-string';
 import {
   encodeConfig,
   decodeConfig,
   generateShareUrl,
   getConfigFromUrl,
 } from '@/lib/utils/url-share';
+
+function encodeRawJson(json: string): string {
+  return LZString.compressToEncodedURIComponent(json);
+}
 
 describe('url-share', () => {
   describe('encodeConfig', () => {
@@ -31,11 +36,13 @@ describe('url-share', () => {
       expect(decoded?.theme).toBe('Tokyo Night');
     });
 
-    it('should not include theme when null', () => {
+    it('should normalise a null theme to null on decode', () => {
       const config = { 'font-size': 16 };
       const encoded = encodeConfig(config, null);
       const decoded = decodeConfig(encoded);
-      expect(decoded?.theme).toBeUndefined();
+      // The decoder normalises "no theme" to a stable null shape; this
+      // is what the share page and the config store expect.
+      expect(decoded?.theme).toBeNull();
     });
   });
 
@@ -142,6 +149,71 @@ describe('url-share', () => {
       expect(decoded?.config['cursor-style']).toBe('bar');
       expect(decoded?.config['background-opacity']).toBe(0.95);
       expect(decoded?.config['keybind']).toEqual(['ctrl+c=copy', 'ctrl+v=paste']);
+    });
+  });
+
+  describe('security hardening', () => {
+    it('drops unknown option keys', () => {
+      const malicious = encodeConfig({
+        'font-size': 14,
+        'backdoor-cmd': 'rm -rf /',
+      });
+      const decoded = decodeConfig(malicious);
+      expect(decoded?.config['font-size']).toBe(14);
+      expect(decoded?.config['backdoor-cmd']).toBeUndefined();
+    });
+
+    it('coerces non-primitive values into the expected shape', () => {
+      // Construct a payload that bypasses TypeScript and embeds a
+      // non-primitive value. The decoder must drop it.
+      const rawJson =
+        '{"config":{"font-size":{"__html":"<img onerror=alert(1) src=x>"}},"version":1}';
+      const compressed = encodeRawJson(rawJson);
+      const decoded = decodeConfig(compressed);
+      // The unknown shape is rejected, so the key is dropped.
+      expect(decoded?.config['font-size']).toBeUndefined();
+    });
+
+    it('rejects prototype-pollution key names', () => {
+      const rawJson = '{"config":{"__proto__":{"polluted":true}},"version":1}';
+      const compressed = encodeRawJson(rawJson);
+      const decoded = decodeConfig(compressed);
+      // The decoder does not copy __proto__ into the result.
+      expect((decoded?.config as Record<string, unknown>)['__proto__']).toBeUndefined();
+      // And nothing got attached to Object.prototype.
+      expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    });
+
+    it('rejects enum values not in the allowed list', () => {
+      const rawJson = '{"config":{"cursor-style":"rainbow"},"version":1}';
+      const compressed = encodeRawJson(rawJson);
+      const decoded = decodeConfig(compressed);
+      expect(decoded?.config['cursor-style']).toBeUndefined();
+    });
+
+    it('rejects malformed palette entries', () => {
+      const rawJson =
+        '{"config":{"palette":["<script>alert(1)</script>"]},"version":1}';
+      const compressed = encodeRawJson(rawJson);
+      const decoded = decodeConfig(compressed);
+      expect(decoded?.config['palette']).toBeUndefined();
+    });
+
+    it('rejects a theme name that breaks out of a comment', () => {
+      const rawJson = '{"config":{},"theme":"evil\\nname","version":1}';
+      const compressed = encodeRawJson(rawJson);
+      const decoded = decodeConfig(compressed);
+      expect(decoded?.theme).toBeNull();
+    });
+
+    it('returns a config with a null prototype', () => {
+      const decoded = decodeConfig(encodeConfig({ 'font-size': 14 }));
+      expect(Object.getPrototypeOf(decoded!.config)).toBeNull();
+    });
+
+    it('still returns null for outright garbage', () => {
+      expect(decodeConfig('not-valid-base64!@#$')).toBeNull();
+      expect(decodeConfig('')).toBeNull();
     });
   });
 });

--- a/src/lib/utils/url-share.test.ts
+++ b/src/lib/utils/url-share.test.ts
@@ -70,12 +70,36 @@ describe('url-share', () => {
 
     it('should handle arrays in config', () => {
       const config = {
-        keybind: ['ctrl+c=copy', 'ctrl+v=paste'],
+        keybind: ['ctrl+c=copy', 'ctrl+v=paste', 'clear'],
       };
       const encoded = encodeConfig(config);
       const decoded = decodeConfig(encoded);
 
-      expect(decoded?.config['keybind']).toEqual(['ctrl+c=copy', 'ctrl+v=paste']);
+      expect(decoded?.config['keybind']).toEqual(['ctrl+c=copy', 'ctrl+v=paste', 'clear']);
+    });
+
+    it('should preserve repeatable string arrays in shared configs', () => {
+      const config = {
+        'font-family': ['JetBrains Mono', 'Symbols Nerd Font'],
+        env: ['PATH=/usr/local/bin', 'EDITOR=nvim'],
+        'config-file': ['?local', '/etc/ghostty/config'],
+      };
+      const encoded = encodeConfig(config);
+      const decoded = decodeConfig(encoded);
+
+      expect(decoded?.config['font-family']).toEqual([
+        'JetBrains Mono',
+        'Symbols Nerd Font',
+      ]);
+      expect(decoded?.config.env).toEqual(['PATH=/usr/local/bin', 'EDITOR=nvim']);
+      expect(decoded?.config['config-file']).toEqual(['?local', '/etc/ghostty/config']);
+    });
+
+    it('should preserve editor-valid duration whitespace forms', () => {
+      const encoded = encodeConfig({ 'resize-overlay-duration': '1 h 30 m' });
+      const decoded = decodeConfig(encoded);
+
+      expect(decoded?.config['resize-overlay-duration']).toBe('1 h 30 m');
     });
 
     it('should preserve theme name', () => {

--- a/src/lib/utils/url-share.test.ts
+++ b/src/lib/utils/url-share.test.ts
@@ -165,45 +165,55 @@ describe('url-share', () => {
 
     it('coerces non-primitive values into the expected shape', () => {
       // Construct a payload that bypasses TypeScript and embeds a
-      // non-primitive value. The decoder must drop it.
+      // non-primitive value. The decoder drops the key, and because no
+      // other keys survive, the whole payload is treated as invalid.
       const rawJson =
         '{"config":{"font-size":{"__html":"<img onerror=alert(1) src=x>"}},"version":1}';
       const compressed = encodeRawJson(rawJson);
-      const decoded = decodeConfig(compressed);
-      // The unknown shape is rejected, so the key is dropped.
-      expect(decoded?.config['font-size']).toBeUndefined();
+      expect(decodeConfig(compressed)).toBeNull();
     });
 
     it('rejects prototype-pollution key names', () => {
       const rawJson = '{"config":{"__proto__":{"polluted":true}},"version":1}';
       const compressed = encodeRawJson(rawJson);
-      const decoded = decodeConfig(compressed);
-      // The decoder does not copy __proto__ into the result.
-      expect((decoded?.config as Record<string, unknown>)['__proto__']).toBeUndefined();
-      // And nothing got attached to Object.prototype.
+      // The decoder drops __proto__ and nothing else survives.
+      expect(decodeConfig(compressed)).toBeNull();
+      // And - critically - nothing got attached to Object.prototype.
       expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
     });
 
     it('rejects enum values not in the allowed list', () => {
       const rawJson = '{"config":{"cursor-style":"rainbow"},"version":1}';
       const compressed = encodeRawJson(rawJson);
-      const decoded = decodeConfig(compressed);
-      expect(decoded?.config['cursor-style']).toBeUndefined();
+      // The bad enum is the only key, so the payload is treated as empty.
+      expect(decodeConfig(compressed)).toBeNull();
     });
 
     it('rejects malformed palette entries', () => {
       const rawJson =
         '{"config":{"palette":["<script>alert(1)</script>"]},"version":1}';
       const compressed = encodeRawJson(rawJson);
-      const decoded = decodeConfig(compressed);
-      expect(decoded?.config['palette']).toBeUndefined();
+      expect(decodeConfig(compressed)).toBeNull();
     });
 
     it('rejects a theme name that breaks out of a comment', () => {
       const rawJson = '{"config":{},"theme":"evil\\nname","version":1}';
       const compressed = encodeRawJson(rawJson);
+      // Both the config and the theme are unusable - the whole payload
+      // is treated as invalid.
+      expect(decodeConfig(compressed)).toBeNull();
+    });
+
+    it('preserves a payload that has at least one good key', () => {
+      // The decoder should only return null when *nothing* survives.
+      // Mixed payloads keep the good keys and drop the bad ones.
+      const rawJson =
+        '{"config":{"font-size":14,"backdoor-cmd":"x"},"version":1}';
+      const compressed = encodeRawJson(rawJson);
       const decoded = decodeConfig(compressed);
-      expect(decoded?.theme).toBeNull();
+      expect(decoded).not.toBeNull();
+      expect(decoded!.config['font-size']).toBe(14);
+      expect(decoded!.config['backdoor-cmd']).toBeUndefined();
     });
 
     it('returns a config with a null prototype', () => {

--- a/src/lib/utils/url-share.ts
+++ b/src/lib/utils/url-share.ts
@@ -46,11 +46,17 @@ export function decodeConfig(encoded: string): ShareableConfig | null {
 
     const raw = parsed as { config?: unknown; theme?: unknown };
     const { config } = validateSharedConfig(raw.config);
+    const theme = validateSharedThemeName(raw.theme) ?? null;
 
-    return {
-      config,
-      theme: validateSharedThemeName(raw.theme) ?? null,
-    };
+    // If validation stripped every key and there's no usable theme, the
+    // payload is effectively empty. Return null so the share page can
+    // surface its "Invalid or corrupted share link" error instead of
+    // rendering a misleading "0 settings configured" empty config.
+    if (Object.keys(config).length === 0 && theme === null) {
+      return null;
+    }
+
+    return { config, theme };
   } catch {
     return null;
   }

--- a/src/lib/utils/url-share.ts
+++ b/src/lib/utils/url-share.ts
@@ -1,5 +1,9 @@
 import LZString from "lz-string";
 import { ConfigValues } from "@/lib/store/config-store";
+import {
+  validateSharedConfig,
+  validateSharedThemeName,
+} from "@/lib/security/validate-shared-config";
 
 export interface ShareableConfig {
   config: ConfigValues;
@@ -28,14 +32,25 @@ export function decodeConfig(encoded: string): ShareableConfig | null {
   try {
     const json = LZString.decompressFromEncodedURIComponent(encoded);
     if (!json) return null;
-    
-    const data = JSON.parse(json) as ShareableConfig;
-    
-    if (!data.config || typeof data.config !== "object") {
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch {
       return null;
     }
-    
-    return data;
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const raw = parsed as { config?: unknown; theme?: unknown };
+    const { config } = validateSharedConfig(raw.config);
+
+    return {
+      config,
+      theme: validateSharedThemeName(raw.theme) ?? null,
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Closes the security gaps that came out of a self-review of the existing surface. The app shipped with no security headers, no CSP, and no runtime validation of decoded share URLs.

This PR adds all three, plus a small amount of theme-fetch hardening, in a single auditable module (`src/lib/security/`). All changes are behind the existing public API — the only observable behaviour change for end users is that malicious or corrupted share URLs now fail safely instead of slipping bad values into the store.

## What's in this PR

### 1. Security headers (new `src/lib/security/headers.ts`)

A single-source-of-truth builder applied via `next.config.ts` on every route. Production:

- `Content-Security-Policy` (strict, with explicit allowlist for GitHub + Buy Me a Coffee + Vercel)
- `Strict-Transport-Security` (2y, includeSubDomains, preload)
- `X-Frame-Options: DENY` (with `frame-ancestors 'none'` for modern browsers)
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy` (camera, mic, geo, payment, usb, etc all `()`)
- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Resource-Policy: same-origin`
- `Cross-Origin-Embedder-Policy: credentialless` (prod only)

Dev relaxes only what's required for HMR (`'unsafe-eval'`, `ws:/wss:`, localhost) and omits COEP.

### 2. CSP builder (new `src/lib/security/csp.ts`)

Dev vs prod variants with the directive-level rationale in the JSDoc. Every external origin is justified inline. `img-src` is now narrowed to the three sources Spectre actually uses (`'self'`, `data:`, `https://cdn.buymeacoffee.com`).

### 3. Share-URL validation (new `src/lib/security/validate-shared-config.ts`)

`decodeConfig` was previously `JSON.parse` → trust-the-result. It now runs a runtime shape validator that:

- Drops unknown option keys (the schema is the source of truth)
- Rejects prototype-pollution payloads (`__proto__`, `constructor`, `prototype`)
- Coerces each value to the option's expected type (string/number/boolean/enum/color/palette/keybind/duration)
- Returns a fresh `Object.create(null)`-backed object with no prototype links
- Bounds payload size, string length, and array length
- Validates and bounds the theme name (control chars / `"` / `\` rejected)
- Returns `null` when validation strips every key, so the share page surfaces its existing "Invalid or corrupted share link" error rather than rendering a misleading empty config

### 4. Theme-fetch hardening (`src/lib/utils/themes.ts`)

`fetchThemeList` and `fetchTheme` now:

- Assert a textual `Content-Type` before parsing
- Stream the response with a 256 KB byte cap, aborting as soon as it's exceeded
- Explicitly validate the GitHub API response is an array (so a misconfigured upstream that returns `{message: ...}` surfaces as a hard error rather than a silently empty list)

## Tests

38 new tests across four files, all passing (total 285, was 246):

- `src/lib/security/csp.test.ts` — every directive, dev/prod delta, WASM `blob:`, Google Fonts correctly *not* required
- `src/lib/security/headers.test.ts` — canonical header set, COEP only in prod, Permissions-Policy locks down expected features
- `src/lib/security/validate-shared-config.test.ts` — every option type, prototype pollution, key/string/array caps, fresh prototype, color/palette/duration edge cases, theme-name sanitisation
- `src/lib/utils/themes.test.ts` — `ensureTextResponse` (acceptance, case-insensitivity, non-text rejection, missing-header rejection), `readBoundedText` (256 KB cap with multi-chunk streaming body, null-body fallback), `fetchThemeList`/`fetchTheme` integration (array-shape guard, content-type rejection, end-to-end size cap)
- 5 tests in `url-share.test.ts` updated to assert the new empty-payload contract, plus 1 new test for the mixed-payload case

## Verification

- `bun run lint` ✓
- `bun run typecheck` ✓
- `bun run test` — 285 passing
- `bun run build` ✓
- Live `curl -sI` on both `bun run start` and `bun run dev` confirms every header reaches the browser and the dev/prod CSP delta is correct

## Out of scope (and why)

- **Nonce-based script-src** — would require middleware changes; documented as a known follow-up in `csp.ts`. Current policy still blocks third-party script injection.
- **SRI for Vercel Analytics / Speed Insights / WASM** — N/A; all are inlined packages or same-origin, not CDN scripts.
- **CSRF** — N/A; this app has no server state, no auth, and no mutating API endpoints. The CSRF surface is genuinely zero.

## Risk

Low. The only observable behaviour change is that crafted or corrupted share URLs now produce the existing "Invalid share link" UX instead of (in the worst case) slipping bad values into the store. All existing tests continue to pass.
