### PR TITLE
fix: map repeatable font families in preview

### DIFF
--- a/src/lib/ghostty/config-mapper.test.ts
+++ b/src/lib/ghostty/config-mapper.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { mapConfigToTheme } from '@/lib/ghostty/config-mapper';
+import {
+  mapConfigToTerminalOptions,
+  mapConfigToTheme,
+} from '@/lib/ghostty/config-mapper';
 
 describe('config mapper', () => {
+  describe('mapConfigToTerminalOptions', () => {
+    it('uses a scalar font-family value unchanged', () => {
+      const options = mapConfigToTerminalOptions({
+        'font-family': 'JetBrains Mono',
+      });
+
+      expect(options.fontFamily).toBe('JetBrains Mono');
+    });
+
+    it('maps repeatable font-family values to a browser CSS fallback stack', () => {
+      const options = mapConfigToTerminalOptions({
+        'font-family': ['JetBrains Mono', 'Symbols Nerd Font'],
+      });
+
+      expect(options.fontFamily).toBe('"JetBrains Mono", "Symbols Nerd Font", monospace');
+    });
+
+    it('falls back to monospace when font-family is empty', () => {
+      const options = mapConfigToTerminalOptions({
+        'font-family': ['', '   '],
+      });
+
+      expect(options.fontFamily).toBe('monospace');
+    });
+  });
+
   describe('mapConfigToTheme', () => {
     it('maps Ghostty indexed palette entries to terminal ANSI theme colors', () => {
       const theme = mapConfigToTheme({

--- a/src/lib/ghostty/config-mapper.ts
+++ b/src/lib/ghostty/config-mapper.ts
@@ -61,9 +61,57 @@ function mapCursorBlink(blink: unknown): boolean {
   return false;
 }
 
+const CSS_GENERIC_FONT_FAMILIES = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "emoji",
+  "math",
+  "fangsong",
+]);
+
+function formatCssFontFamily(family: string): string {
+  const trimmed = family.trim();
+
+  if (CSS_GENERIC_FONT_FAMILIES.has(trimmed.toLowerCase())) {
+    return trimmed;
+  }
+
+  if (/^[a-zA-Z_][\w-]*$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `"${trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function mapFontFamily(fontFamily: unknown): string {
+  if (Array.isArray(fontFamily)) {
+    const families = fontFamily
+      .filter((family): family is string => typeof family === "string")
+      .map((family) => family.trim())
+      .filter(Boolean)
+      .map(formatCssFontFamily);
+
+    return families.length > 0 ? [...families, "monospace"].join(", ") : "monospace";
+  }
+
+  if (typeof fontFamily === "string" && fontFamily.trim() !== "") {
+    return fontFamily;
+  }
+
+  return "monospace";
+}
+
 export function mapConfigToTerminalOptions(config: ConfigValues): ITerminalOptions {
   const fontSize = (config["font-size"] as number) || 13;
-  const fontFamily = (config["font-family"] as string) || "monospace";
+  const fontFamily = mapFontFamily(config["font-family"]);
   const cursorStyle = mapCursorStyle((config["cursor-style"] as string) || "block");
   const cursorBlink = mapCursorBlink(config["cursor-style-blink"]);
 


### PR DESCRIPTION
## Summary
- map repeatable `font-family` values to a browser CSS fallback stack for the Ghostty preview
- keep scalar font-family behavior unchanged
- fall back to `monospace` for empty repeatable values

## Verification
- `bun run test -- --run`
- `bun run build`