### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ## Unreleased
 
+## [0.3.0] - 2026-07-03
+
 ### Added
 
 - Added a repeatable text input for Ghostty string options that can be specified multiple times, such as `font-family`, `env`, `config-file`, `custom-shader`, and `gtk-custom-css`.
@@ -19,6 +21,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Added a `src/lib/security/` module that builds a strict Content Security Policy and a full security header set, with separate dev and prod variants.
 - Added a runtime shape validator for shared configuration URLs that drops unknown option keys, coerces values to their schema type, rejects prototype-pollution payloads, and bounds payload size.
 - Added unit tests covering the new CSP, headers, and shared-config validators.
+- Added support for Ghostty keybind chains (`chain=<action>`), key tables (`resize/ctrl+h=resize_split:left,10`), key table clears (`resize/`), and slash-key triggers (`ctrl+/=new_tab`), plus the `activate_key_table_once` and `deactivate_all_key_tables` actions.
 
 ### Changed
 
@@ -29,12 +32,15 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - `next.config.ts` now applies a strict set of security headers to every route: `Content-Security-Policy`, `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, and `Cross-Origin-Embedder-Policy` (prod only).
 - `decodeConfig` now normalises share payloads to a known shape (no prototype chain, no unknown keys, no non-primitive values); a missing theme is now `null` everywhere instead of `undefined`.
 - `fetchThemeList` and `fetchTheme` now assert a textual `content-type` and stream the response with a 256 KB byte cap to prevent hostile or compromised upstreams from streaming arbitrary content into the parser.
+- Shared configuration keybind validation is now intentionally coarse for `trigger=action` entries so older or future-compatible bindings are not dropped from share links.
 
 ### Fixed
 
 - Accepted Ghostty color values that use short hex, hex without `#`, or named X11 colors in color inputs.
 - Cleared stale applied-theme metadata when importing configs or editing theme-derived color values.
 - Ignored generated coverage output in ESLint and replaced the landing page coffee button image with `next/image`.
+- Mapped repeatable `font-family` values to a browser CSS fallback stack in the terminal preview, falling back to `monospace` for empty values.
+- Preserved Ghostty key table clear entries (`keybind = resize/`) when encoding and decoding shared configuration URLs.
 
 ## [0.2.0] - 2026-06-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectre-ghostty-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A beautiful, modern configuration generator for Ghostty terminal",
   "author": "imrajyavardhan12",
   "license": "MIT",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const SPECTRE_VERSION = "0.2.0";
+export const SPECTRE_VERSION = "0.3.0";


### PR DESCRIPTION
## Summary
- bump `package.json` and `src/lib/version.ts` to 0.3.0
- move CHANGELOG Unreleased entries into a dated 0.3.0 section per RELEASE.md

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test -- --run` (311 passed)
- `bun run build`
- `bun run schema:check` (in sync with Ghostty config reference)