### PR TITLE
chore: ignore .factory/ agent workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ next-env.d.ts
 AGENTS.md
 AGENT.md
 
+# Factory agent workspace
+.factory/
+
 # WASM files (copied from node_modules)
 public/ghostty-vt.wasm


### PR DESCRIPTION
## Summary
- add `.factory/` to `.gitignore` so the local Factory agent workspace directory can never be accidentally staged/committed again