### PR TITLE
chore: restore engineering health checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ## Unreleased
 
+### Changed
+
+- Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
+- Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
+- Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.
+
+### Fixed
+
+- Removed a stale Ghostty documentation anchor alias that caused the weekly schema drift check to fail after upstream restored the canonical `shell-integration` anchor.
+
 ## [0.3.0] - 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "imrajyavardhan12",
   "license": "MIT",
   "private": true,
+  "packageManager": "bun@1.2.22",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -12,7 +13,6 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "schema:check": "bun run scripts/check-ghostty-schema-drift.ts",
-    "format": "prettier --write .",
     "postinstall": "cp node_modules/ghostty-web/ghostty-vt.wasm public/ 2>/dev/null || true",
     "test": "vitest",
     "test:watch": "vitest watch",

--- a/src/lib/utils/schema-drift.test.ts
+++ b/src/lib/utils/schema-drift.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   DOCS_ONLY_REFERENCE_ANCHORS,
-  REFERENCE_ANCHOR_ID_ALIASES,
   createGhosttySchemaDriftReport,
   extractGhosttyReferenceAnchorIds,
 } from '@/lib/utils/schema-drift';
@@ -46,7 +45,6 @@ describe('Ghostty schema drift utilities', () => {
       referenceAnchorIds: ['font-family', 'theme', 'chained-actions', 'key-tables'],
       localOptionIds: ['theme', 'font-family'],
       docsOnlyAnchorIds: DOCS_ONLY_REFERENCE_ANCHORS,
-      referenceAnchorIdAliases: {},
     });
 
     expect(report.ok).toBe(true);
@@ -71,7 +69,7 @@ describe('Ghostty schema drift utilities', () => {
       referenceAnchorIds: ['font-family', 'shell-integration-3', 'shell-integration-features'],
       localOptionIds: ['font-family', 'shell-integration', 'shell-integration-features'],
       docsOnlyAnchorIds: [],
-      referenceAnchorIdAliases: REFERENCE_ANCHOR_ID_ALIASES,
+      referenceAnchorIdAliases: { 'shell-integration-3': 'shell-integration' },
     });
 
     expect(report.ok).toBe(true);

--- a/src/lib/utils/schema-drift.ts
+++ b/src/lib/utils/schema-drift.ts
@@ -8,21 +8,11 @@ export const DOCS_ONLY_REFERENCE_ANCHORS = [
   "key-tables",
 ] as const;
 
-// Ghostty's docs site occasionally disambiguates two headings that share a
-// visible slug by appending a numeric suffix to one heading's anchor `id`,
-// even though the heading text (and the real Ghostty option name) is
-// unaffected. Map the drifted anchor id back to the real option id here.
-// Keep this list intentionally small and documented so it stays reviewable.
-//
-// - "shell-integration-3": the `shell-integration` option heading itself
-//   renders with id="shell-integration-3" upstream, while the page's own
-//   sidecar table of contents still links to "#shell-integration". The
-//   option is unchanged in Ghostty's source
-//   (https://github.com/ghostty-org/ghostty/blob/main/src/config/Config.zig,
-//   `@"shell-integration"`). Verified 2026-07-06.
-export const REFERENCE_ANCHOR_ID_ALIASES: Readonly<Record<string, string>> = {
-  "shell-integration-3": "shell-integration",
-};
+// Ghostty's docs site may disambiguate duplicate heading slugs by appending a
+// numeric suffix to an anchor `id`. Map any active drifted anchor ids back to
+// their real option ids here. Keep this list intentionally small, documented,
+// and temporary: stale aliases deliberately fail the drift check.
+export const REFERENCE_ANCHOR_ID_ALIASES: Readonly<Record<string, string>> = {};
 
 const CONFIG_REFERENCE_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
 const HTML_TAG_PATTERN = /<[^>]+>/g;


### PR DESCRIPTION
## Summary

- remove the stale `shell-integration-3` reference alias now that Ghostty restored its canonical documentation anchor
- make the default alias configuration part of the schema-drift regression test
- switch Dependabot from the npm ecosystem to its Bun ecosystem so updates include `bun.lock`
- pin the repository package manager to the Bun version used by CI
- remove the unusable Prettier script instead of introducing a 92-file formatting rewrite into a functional change

## Why

The weekly Ghostty schema-drift workflow has failed for two consecutive runs despite Spectre matching all 202 upstream options. All five open Dependabot PRs also fail frozen installation because the npm updater changes `package.json` without maintaining `bun.lock`.

After merge, the existing npm-generated Dependabot PRs should be closed and recreated by the Bun updater.

## Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test -- --run` — 313 tests passed
- `bun run build`
- `bun run schema:check` — 202 local options match 202 upstream options
- Dependabot YAML parsed successfully
