### PR TITLE
docs: establish open source contribution framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership for review routing.
+* @imrajyavardhan12

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: rvs12

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report reproducible behavior that is incorrect in Spectre
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Remove secrets, tokens, hostnames, usernames, and personal paths from configurations and screenshots.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and pull requests for this problem.
+          required: true
+        - label: I confirmed this is a Spectre problem rather than Ghostty behavior that also occurs without Spectre.
+          required: true
+        - label: I removed sensitive information from the report.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem
+      description: Describe what went wrong and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that reproduces the problem.
+      placeholder: |
+        1. Open ...
+        2. Set ...
+        3. Export ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal configuration or share link
+      description: Include only what is needed to reproduce the problem. Remove sensitive values.
+      render: shell
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: Firefox 140, Chrome 140, Safari 19
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      placeholder: macOS 16, Ubuntu 26.04, Windows 11
+    validations:
+      required: true
+
+  - type: input
+    id: ghostty-version
+    attributes:
+      label: Ghostty version
+      description: If the problem involves imported or generated Ghostty behavior.
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots, console output, or additional context
+      description: Drag files here. Redact personal information first.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and support
+    url: https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions/categories/q-a
+    about: Ask for usage help or troubleshoot an unconfirmed problem.
+  - name: Explore an idea
+    url: https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions/categories/ideas
+    about: Discuss early or broad product ideas before opening an issue.
+  - name: Report a security vulnerability
+    url: https://github.com/imrajyavardhan12/spectre-ghostty-config/security/advisories/new
+    about: Report vulnerabilities privately. Do not create a public issue.
+  - name: Ghostty support
+    url: https://github.com/ghostty-org/ghostty/discussions
+    about: Ask about behavior that occurs in Ghostty independently of Spectre.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Propose a concrete improvement to Spectre
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with the user problem. Early ideas and broad discussion belong in GitHub Discussions.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues, pull requests, and Discussions.
+          required: true
+        - label: This request relates to Spectre rather than a change required in Ghostty itself.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Who has this problem, and what are they unable to do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the successful user outcome without prescribing implementation details.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Optional implementation or interaction ideas.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing workarounds or other approaches you considered.
+
+  - type: textarea
+    id: upstream
+    attributes:
+      label: Ghostty source or documentation
+      description: Link relevant Ghostty documentation, source, or release notes when applicable.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, examples, or related projects are welcome.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- What changed, and why is this the smallest coherent solution? -->
+
+## Related issue
+
+<!-- Use "Closes #123" when applicable. -->
+
+## Change type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Refactoring or maintenance
+- [ ] Ghostty compatibility update
+
+## Ghostty source of truth
+
+<!-- Link the official config reference, documentation, source, or release notes when Ghostty behavior changes. Otherwise write "Not applicable." -->
+
+## Verification
+
+<!-- List automated checks and manual scenarios you ran. -->
+
+- [ ] `bun run lint`
+- [ ] `bun run typecheck`
+- [ ] `bun run test -- --run`
+- [ ] `bun run build`
+- [ ] `bun run schema:check` when Ghostty options changed
+
+## Visual evidence
+
+<!-- Add before/after screenshots or a recording for UI changes. Otherwise write "Not applicable." -->
+
+## Checklist
+
+- [ ] The change is focused and does not include unrelated formatting or refactoring.
+- [ ] Tests cover observable behavior and important failure paths.
+- [ ] User-facing behavior and `CHANGELOG.md` are updated where needed.
+- [ ] UI changes were checked with keyboard navigation and responsive layouts.
+- [ ] No secrets, personal configuration, or sensitive data are included.
+- [ ] I have read and followed `CONTRIBUTING.md` and the Code of Conduct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.
+- Added contributor, security, support, conduct, roadmap, issue, pull request, ownership, and funding documentation for a clearer open-source workflow.
 
 ### Fixed
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainer at **srajyavardhan12@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+The project maintainer is obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any interaction or public communication with the community for a specified period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to Spectre
+
+Thanks for helping make Ghostty configuration easier and safer. Contributions of code, documentation, testing, design feedback, and upstream research are welcome.
+
+## Before you start
+
+- Search existing [issues](https://github.com/imrajyavardhan12/spectre-ghostty-config/issues) and [pull requests](https://github.com/imrajyavardhan12/spectre-ghostty-config/pulls).
+- Use [GitHub Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions) for support, questions, and early ideas.
+- Open an issue before substantial changes so scope and behavior can be agreed before implementation.
+- Report vulnerabilities privately according to [SECURITY.md](SECURITY.md), not in a public issue.
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development setup
+
+Prerequisites:
+
+- [Git](https://git-scm.com/)
+- [Bun](https://bun.sh/) at the version declared by `packageManager` in `package.json`
+
+```bash
+git clone https://github.com/YOUR_USERNAME/spectre-ghostty-config.git
+cd spectre-ghostty-config
+bun install --frozen-lockfile
+bun run dev
+```
+
+Open <http://localhost:3000>.
+
+## Useful commands
+
+| Command | Purpose |
+| --- | --- |
+| `bun run dev` | Start the development server |
+| `bun run lint` | Run ESLint |
+| `bun run typecheck` | Run TypeScript checking |
+| `bun run test -- --run` | Run the test suite once |
+| `bun run test:watch` | Run tests in watch mode |
+| `bun run test:coverage -- --run` | Generate test coverage |
+| `bun run build` | Create a production build |
+| `bun run schema:check` | Compare local options with Ghostty's reference |
+
+A repository-wide formatter is not currently enforced. Match the surrounding file and let ESLint catch enforceable style problems. Avoid unrelated formatting changes.
+
+## Working on Ghostty configuration behavior
+
+Ghostty itself is the source of truth. Check sources in this order:
+
+1. [Ghostty Config Reference](https://ghostty.org/docs/config/reference)
+2. [Ghostty documentation](https://ghostty.org/docs)
+3. [Ghostty source](https://github.com/ghostty-org/ghostty)
+
+When adding or changing an option:
+
+- Preserve Ghostty's exact kebab-case option name and serialized behavior.
+- Record type, default, platform restrictions, repeatability, and validation accurately.
+- Add focused tests for import, export, validation, sharing, and preview mapping where applicable.
+- Link the relevant upstream documentation or source in the pull request.
+- Run `bun run schema:check` when network access is available.
+
+## Pull request workflow
+
+1. Fork the repository and create a focused branch from current `main`.
+2. Make the smallest coherent change that solves the problem.
+3. Add or update tests for observable behavior.
+4. Update documentation and `CHANGELOG.md` when behavior changes.
+5. Run the relevant checks locally.
+6. Open a pull request using the template and include screenshots for visual changes.
+
+Suggested branch names:
+
+- `feat/theme-filtering`
+- `fix/share-import-validation`
+- `docs/contributor-guide`
+- `chore/update-tooling`
+
+Commit messages generally follow the existing conventional style, such as `feat:`, `fix:`, `docs:`, `test:`, and `chore:`.
+
+## Review expectations
+
+Pull requests are evaluated for:
+
+- correctness against Ghostty behavior
+- focused scope and backwards compatibility
+- tests for important success and failure paths
+- accessibility and responsive behavior for UI changes
+- security at URL, config, browser-storage, and remote-fetch boundaries
+- clear documentation and maintainable implementation
+
+Maintainers may ask for a change to be split when independent concerns would be easier to review separately.
+
+## Getting help
+
+If you are unsure where to begin, look for [`good first issue`](https://github.com/imrajyavardhan12/spectre-ghostty-config/labels/good%20first%20issue) or [`help wanted`](https://github.com/imrajyavardhan12/spectre-ghostty-config/labels/help%20wanted) issues, or ask in [Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions).

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
   <h1>👻</h1>
   <h3>A beautiful, modern configuration generator for Ghostty terminal</h3>
   <p>
-    <a href="https://ghostty.org">Ghostty</a> •
+    <a href="https://spectre-ghostty-config.vercel.app">Open Spectre</a> •
     <a href="#features">Features</a> •
     <a href="#getting-started">Getting Started</a> •
+    <a href="#roadmap">Roadmap</a> •
     <a href="#contributing">Contributing</a>
+  </p>
+  <p>
+    <a href="https://github.com/imrajyavardhan12/spectre-ghostty-config/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/imrajyavardhan12/spectre-ghostty-config/actions/workflows/ci.yml/badge.svg" /></a>
+    <a href="https://github.com/imrajyavardhan12/spectre-ghostty-config/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/imrajyavardhan12/spectre-ghostty-config" /></a>
+    <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/imrajyavardhan12/spectre-ghostty-config" /></a>
   </p>
 </div>
 
@@ -111,15 +117,21 @@ to compare Spectre's local option IDs against the official Ghostty config refere
 | **Linux** | Linux/GTK-specific settings |
 | **Advanced** | Scrollback, shaders, image storage |
 
+## Roadmap
+
+Current priorities are upstream Ghostty correctness, end-to-end confidence, accessibility, preview resilience, and contributor readiness. See the [public roadmap](ROADMAP.md) for planned work and prioritization principles.
+
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, Ghostty source-of-truth requirements, and the pull request workflow.
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+- Browse [`good first issue`](https://github.com/imrajyavardhan12/spectre-ghostty-config/labels/good%20first%20issue) and [`help wanted`](https://github.com/imrajyavardhan12/spectre-ghostty-config/labels/help%20wanted) work.
+- Ask questions or explore early ideas in [GitHub Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions).
+- Read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+## Support and security
+
+Use [SUPPORT.md](SUPPORT.md) to choose between Discussions, issues, and upstream Ghostty support. Report vulnerabilities privately according to [SECURITY.md](SECURITY.md); do not open a public security issue.
 
 ## Acknowledgements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,49 @@
+# Spectre Roadmap
+
+Spectre's goal is to be the most trustworthy and approachable way to create a Ghostty configuration. This roadmap communicates direction rather than fixed delivery dates.
+
+## Product principles
+
+1. **Ghostty is the source of truth.** Generated configuration must match upstream behavior.
+2. **Trust before breadth.** Import, export, sharing, and preview behavior must be safe and reversible.
+3. **Fast visual feedback.** Configuration changes should be understandable without trial-and-error editing.
+4. **Accessible everywhere.** Core workflows should work with keyboards, assistive technology, and mobile screens.
+5. **Welcoming maintenance.** Contributors should be able to understand, test, and review changes confidently.
+
+## Now — reliability and contributor foundation
+
+- Keep the option schema synchronized with Ghostty upstream.
+- Establish contributor, security, support, and issue workflows.
+- Add end-to-end coverage for import → edit → preview → export/share.
+- Audit editor and theme-browser accessibility.
+- Improve recovery when WASM preview initialization or remote theme fetching fails.
+- Publish a clear compatibility statement for Spectre and Ghostty versions.
+
+## Next — best-in-class editing experience
+
+- Improve onboarding for users importing their first configuration.
+- Make validation messages more actionable and source-linked.
+- Refine editor navigation, search, keyboard operation, and mobile layouts.
+- Improve theme discovery, comparison, and preview performance.
+- Add confidence checks for keybind conflicts and platform-specific settings.
+
+## Later — deeper Ghostty workflows
+
+- Ghostty version selection and compatibility filtering.
+- Curated, community-reviewed presets.
+- Local configuration history and safer recovery.
+- Installable PWA support where it improves real workflows.
+- More advanced preview scenarios and configuration comparisons.
+
+## How priorities are chosen
+
+Work is prioritized by:
+
+1. correctness, security, or data-loss risk
+2. upstream Ghostty compatibility
+3. impact on common user workflows
+4. accessibility and reliability
+5. contributor readiness and maintenance cost
+6. community demand with a clear problem statement
+
+Propose changes through [GitHub Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions) or a focused issue. Accepted ideas may move between sections as upstream Ghostty and community needs evolve.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+Spectre is a hosted web application. Security fixes are applied to the latest deployment and the current `main` branch. Older tags are historical snapshots and do not receive separate security updates.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting flow:
+
+**[Report a vulnerability privately](https://github.com/imrajyavardhan12/spectre-ghostty-config/security/advisories/new)**
+
+Include, when possible:
+
+- the affected route, component, or configuration field
+- reproduction steps or a minimal proof of concept
+- expected and observed impact
+- affected browsers or platforms
+- suggested remediation, if known
+
+Please remove credentials, personal data, and unrelated user configuration from reports.
+
+We aim to acknowledge reports within 72 hours and provide an initial assessment within seven days. Timelines for a fix and disclosure depend on severity and complexity. We will coordinate disclosure with the reporter and credit them unless they prefer to remain anonymous.
+
+## Relevant trust boundaries
+
+Security-sensitive areas include:
+
+- decoding and validating shared configuration URLs
+- importing untrusted Ghostty configuration text
+- rendering configuration-derived values in the browser
+- fetching and parsing themes from external sources
+- browser storage and clipboard interactions
+- Content Security Policy and other deployment headers
+- third-party JavaScript and WASM dependencies
+
+This project does not currently operate a paid bug bounty program.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+## Questions and usage help
+
+Use the [Q&A category in GitHub Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions/categories/q-a) for setup help, Ghostty configuration questions, and troubleshooting that is not yet a confirmed Spectre bug.
+
+When asking for help, include:
+
+- browser and operating system
+- the relevant Ghostty or Spectre version, when known
+- a minimal configuration with secrets and personal paths removed
+- steps already attempted
+
+## Bugs
+
+Use the [bug report form](https://github.com/imrajyavardhan12/spectre-ghostty-config/issues/new?template=bug_report.yml) for reproducible Spectre defects. Search existing issues first.
+
+For Ghostty behavior that also occurs without Spectre, consult the [Ghostty documentation](https://ghostty.org/docs) or the [Ghostty repository](https://github.com/ghostty-org/ghostty).
+
+## Feature ideas
+
+Use [GitHub Discussions](https://github.com/imrajyavardhan12/spectre-ghostty-config/discussions/categories/ideas) to explore early ideas. Use the feature request form once the problem and intended outcome are concrete.
+
+## Security
+
+Report vulnerabilities privately by following [SECURITY.md](SECURITY.md). Do not post sensitive reports in Discussions or public issues.


### PR DESCRIPTION
## Summary

- add contributor setup, workflow, review expectations, and Ghostty source-of-truth guidance
- add security reporting, support routing, a public roadmap, and Contributor Covenant
- add structured bug and feature issue forms plus support/security routing
- add a pull request checklist, CODEOWNERS, and GitHub Sponsors metadata
- improve README navigation, project badges, contribution links, and security guidance

## Repository administration completed alongside this PR

- protected `main` with required PRs, passing `Verify`, linear history, conversation resolution, and force-push/deletion prevention
- enabled private vulnerability reporting
- removed nine stale local/remote branches after verifying their work was merged
- closed the five obsolete npm-generated Dependabot PRs
- confirmed Bun-native Dependabot now updates both `package.json` and `bun.lock`
- improved the repository description/topics and disabled the unused wiki

## Verification

- all GitHub YAML parses successfully
- all relative Markdown links resolve
- external support, Discussions, Ghostty, and private-security links return successfully
- `bun run lint`
- `bun run typecheck`
- `bun run test -- --run` — 313 tests passed
- `bun run build`
