### PR TITLE
test: add critical browser workflow coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,17 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: End-to-end test
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,24 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ## Unreleased
 
+### Added
+
+- Added Playwright browser tests for the landing-to-editor path, import/export, config sharing, mobile navigation, preview recovery, theme-service recovery, and automated WCAG A/AA checks.
+
 ### Changed
 
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.
 - Added contributor, security, support, conduct, roadmap, issue, pull request, ownership, and funding documentation for a clearer open-source workflow.
+- Added Chromium end-to-end tests to the required CI verification job.
 
 ### Fixed
 
 - Removed a stale Ghostty documentation anchor alias that caused the weekly schema drift check to fail after upstream restored the canonical `shell-integration` anchor.
+- Added accessible names to editor actions, option reset controls, documentation links, and sliders.
+- Prevented the editor's mobile category strip from widening the page beyond the viewport.
+- Preserved Ghostty's extensionless `config` filename when downloading from editor and shared-config views.
 
 ## [0.3.0] - 2026-07-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,17 @@ Open <http://localhost:3000>.
 | `bun run typecheck` | Run TypeScript checking |
 | `bun run test -- --run` | Run the test suite once |
 | `bun run test:watch` | Run tests in watch mode |
-| `bun run test:coverage -- --run` | Generate test coverage |
+| `bun run test:coverage -- --run` | Generate unit-test coverage |
+| `bun run test:e2e` | Run browser end-to-end and accessibility tests |
+| `bun run test:e2e:ui` | Open Playwright's interactive test runner |
 | `bun run build` | Create a production build |
 | `bun run schema:check` | Compare local options with Ghostty's reference |
+
+Install Playwright's Chromium build before running browser tests for the first time:
+
+```bash
+bunx playwright install chromium
+```
 
 A repository-wide formatter is not currently enforced. Match the surrounding file and let ESLint catch enforceable style problems. Avoid unrelated formatting changes.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ bun run start
 - **Framework**: [Next.js 16](https://nextjs.org/) (App Router)
 - **Language**: [TypeScript](https://www.typescriptlang.org/)
 - **Terminal Preview**: [ghostty-web](https://github.com/coder/ghostty-web) (libghostty compiled to WASM)
+- **End-to-End Testing**: [Playwright](https://playwright.dev/) with [axe-core](https://github.com/dequelabs/axe-core)
 - **Styling**: [Tailwind CSS 4](https://tailwindcss.com/)
 - **UI Components**: [shadcn/ui](https://ui.shadcn.com/)
 - **State Management**: [Zustand 5](https://zustand-demo.pmnd.rs/)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,8 @@ Spectre's goal is to be the most trustworthy and approachable way to create a Gh
 
 - Keep the option schema synchronized with Ghostty upstream.
 - Establish contributor, security, support, and issue workflows.
-- Add end-to-end coverage for import → edit → preview → export/share.
-- Audit editor and theme-browser accessibility.
+- Expand end-to-end coverage beyond the critical import → edit → preview → export/share path.
+- Continue auditing editor and theme-browser accessibility beyond automated checks.
 - Improve recovery when WASM preview initialization or remote theme fetching fails.
 - Publish a clear compatibility statement for Spectre and Ghostty versions.
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,8 @@
         "zustand": "^5.0.14",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -69,6 +71,8 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -255,6 +259,8 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -552,7 +558,7 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
-    "axe-core": ["axe-core@4.11.0", "", {}, "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ=="],
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -734,7 +740,7 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1007,6 +1013,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1316,6 +1326,8 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-plugin-jsx-a11y/axe-core": ["axe-core@4.11.0", "", {}, "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ=="],
+
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
@@ -1337,6 +1349,8 @@
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "terser/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,6 +23,8 @@ Track Ghostty compatibility separately from the Spectre app version.
    bun run lint
    bun run test -- --run
    bun run build
+   bunx playwright install chromium # first run only
+   bun run test:e2e
    ```
 
 3. Update `CHANGELOG.md`.

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,49 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+const WCAG_AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function findAccessibilityViolations(page: Page) {
+  // Let entrance animations settle so axe measures final colors and opacity.
+  await page.waitForTimeout(1_000);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(WCAG_AA_TAGS)
+    .analyze();
+
+  return results.violations.map(({ id, impact, nodes }) => ({
+    id,
+    impact,
+    targets: nodes.map((node) => node.target),
+  }));
+}
+
+test("the editor has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await expect(page.getByRole("heading", { name: "Fonts" })).toBeVisible();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the landing page has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: /craft your ghostty experience/i })
+  ).toBeVisible();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the mobile editor has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/editor");
+  await expect(page.getByRole("heading", { name: "Fonts" })).toBeVisible();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+import { expect, test, type Route } from "@playwright/test";
+
+test("a user can open the configuration editor", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: /craft your ghostty experience/i })
+  ).toBeVisible();
+
+  await page.getByRole("link", { name: "Open Editor" }).first().click();
+
+  await expect(page).toHaveURL(/\/editor$/);
+  await expect(page.getByRole("heading", { name: "Fonts" })).toBeVisible();
+});
+
+test("a user can edit, inspect, share, and reopen a configuration", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fontSize = page.locator("#option-font-size").getByRole("spinbutton");
+  await fontSize.fill("16");
+
+  await expect(page.getByText("1 modified", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: /view config/i }).click();
+  await expect(page.getByRole("heading", { name: "Generated Config" })).toBeVisible();
+  await expect(page.locator("pre")).toContainText("font-size = 16");
+
+  await page.getByRole("button", { name: "Share", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Link Copied!" })).toBeVisible();
+
+  const shareUrl = await page.evaluate(() => navigator.clipboard.readText());
+  expect(shareUrl).toContain("/share?c=");
+
+  await page.goto(shareUrl);
+  await expect(
+    page.getByRole("heading", { name: "Custom Configuration" })
+  ).toBeVisible();
+  await expect(page.locator("pre")).toContainText("font-size = 16");
+
+  await page.getByRole("button", { name: "Open Editor", exact: true }).click();
+  await expect(page).toHaveURL(/\/editor$/);
+  await expect(
+    page.locator("#option-font-size").getByRole("spinbutton")
+  ).toHaveValue("16");
+});
+
+test("a user can import and export a Ghostty configuration", async ({ page }) => {
+  await page.goto("/editor");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import Config" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "text/plain",
+    buffer: Buffer.from("font-size = 18\ncursor-style = bar\n"),
+  });
+
+  await expect(page.getByText("2 modified", { exact: true })).toBeVisible();
+  await expect(
+    page.locator("#option-font-size").getByRole("spinbutton")
+  ).toHaveValue("18");
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export Config" }).click();
+  const download = await downloadPromise;
+  const downloadPath = await download.path();
+
+  expect(download.suggestedFilename()).toBe("config");
+  expect(downloadPath).not.toBeNull();
+  await expect(readFile(downloadPath!, "utf8")).resolves.toContain(
+    "font-size = 18"
+  );
+  await expect(readFile(downloadPath!, "utf8")).resolves.toContain(
+    "cursor-style = bar"
+  );
+});
+
+test("a user can navigate and inspect configuration on a mobile screen", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/editor");
+
+  await page.getByRole("button", { name: "Colors", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Colors" })).toBeVisible();
+
+  await page.getByRole("button", { name: "View Config" }).click();
+  await expect(page.getByRole("heading", { name: "Generated Config" })).toBeVisible();
+  await expect(page.getByText("No modifications yet")).toBeVisible();
+  await page.waitForTimeout(600);
+
+  const hasHorizontalPageOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth
+  );
+  expect(hasHorizontalPageOverflow).toBe(false);
+});
+
+test("a user can retry the terminal preview after WASM loading fails", async ({
+  page,
+}) => {
+  const wasmUrl = "**/ghostty-vt.wasm";
+  const failWasmRequest = (route: Route) => route.abort("failed");
+  await page.route(wasmUrl, failWasmRequest);
+  await page.goto("/editor");
+
+  await page.getByRole("button", { name: "Open Preview" }).click();
+  await expect(page.getByText("Failed to load preview")).toBeVisible();
+
+  await page.unroute(wasmUrl, failWasmRequest);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByText("Failed to load preview")).not.toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("Loading Ghostty WASM...")).not.toBeVisible();
+});

--- a/e2e/resilience.spec.ts
+++ b/e2e/resilience.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test, type Route } from "@playwright/test";
+
+const themeListUrl =
+  "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
+
+test("a user can retry after the remote theme service fails", async ({ page }) => {
+  const failThemeList = (route: Route) =>
+    route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "Service unavailable" }),
+    });
+  await page.route(themeListUrl, failThemeList);
+
+  await page.goto("/themes");
+  await expect(page.getByText("Failed to load themes")).toBeVisible();
+
+  await page.unroute(themeListUrl, failThemeList);
+  await page.route(themeListUrl, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          type: "file",
+          name: "Dracula",
+          download_url:
+            "https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/ghostty/Dracula",
+        },
+      ]),
+    })
+  );
+  await page.route(
+    "https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/ghostty/Dracula",
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: [
+          "background = #282a36",
+          "foreground = #f8f8f2",
+          "cursor-color = #f8f8f2",
+          "palette = 0=#21222c",
+          "palette = 1=#ff5555",
+          "palette = 2=#50fa7b",
+          "palette = 3=#f1fa8c",
+          "palette = 4=#bd93f9",
+          "palette = 5=#ff79c6",
+          "palette = 6=#8be9fd",
+          "palette = 7=#f8f8f2",
+        ].join("\n"),
+      })
+  );
+
+  await page.getByRole("button", { name: "Try Again" }).click();
+
+  await expect(page.getByRole("heading", { name: "Dracula" })).toBeVisible();
+  await expect(page.getByText("1 of 1 themes loaded")).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test": "vitest",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -46,6 +48,8 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = 3100;
+const webServerCommand = process.env.CI
+  ? `bun run start -- --hostname 127.0.0.1 --port ${port}`
+  : `bun run dev -- --hostname 127.0.0.1 --port ${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    permissions: ["clipboard-read", "clipboard-write"],
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: webServerCommand,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -50,7 +50,7 @@ export default function EditorPage() {
           onCategoryChange={setActiveCategory}
         />
 
-        <main className="flex-1 animate-fade-in">
+        <main className="min-w-0 flex-1 animate-fade-in">
           <MobileCategoryBar
             activeCategory={activeCategory}
             onCategoryChange={setActiveCategory}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,16 +39,17 @@ export default function HomePage() {
               <Image
                 src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
                 alt="Buy Me A Coffee"
-                width={116}
+                width={114}
                 height={32}
+                priority
                 unoptimized
-                className="h-8 w-auto"
               />
             </a>
             <a
               href="https://github.com/imrajyavardhan12/spectre-ghostty-config"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="View Spectre on GitHub"
               className="text-muted-foreground hover:text-foreground transition-colors"
             >
               <Code2 className="h-5 w-5" />

--- a/src/app/share/page.tsx
+++ b/src/app/share/page.tsx
@@ -38,7 +38,7 @@ function SharePageContent() {
   };
 
   const handleDownload = () => {
-    const blob = new Blob([configString], { type: "text/plain" });
+    const blob = new Blob([configString], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/src/components/editor/ConfigOutput.tsx
+++ b/src/components/editor/ConfigOutput.tsx
@@ -55,7 +55,7 @@ export function ConfigOutput() {
 
   const handleDownload = () => {
     setDownloadTooltipOpen(false);
-    const blob = new Blob([configString], { type: "text/plain" });
+    const blob = new Blob([configString], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -78,6 +78,7 @@ export function ConfigOutput() {
     <Sheet open={isOpen} onOpenChange={handleSheetOpenChange}>
       <SheetTrigger asChild>
         <Button 
+          aria-label="View Config"
           className={cn(
             "gap-2 shadow-lg transition-all duration-300",
             modifiedCount > 0 && "shadow-primary/20"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,7 +31,7 @@ export function Header() {
     await new Promise(resolve => setTimeout(resolve, 300));
     
     const configString = exportConfig();
-    const blob = new Blob([configString], { type: "text/plain" });
+    const blob = new Blob([configString], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -116,6 +116,7 @@ export function Header() {
                   variant="ghost" 
                   size="icon" 
                   onClick={handleImport}
+                  aria-label="Import Config"
                   className="relative h-9 w-9"
                 >
                   {importState === "loading" ? (
@@ -141,6 +142,7 @@ export function Header() {
                   variant="ghost" 
                   size="icon" 
                   onClick={handleExport}
+                  aria-label="Export Config"
                   className="h-9 w-9"
                 >
                   {exportState === "loading" ? (
@@ -166,6 +168,7 @@ export function Header() {
                   variant="ghost"
                   size="icon"
                   onClick={resetAll}
+                  aria-label="Reset All"
                   disabled={modifiedCount === 0}
                   className={cn(
                     "h-9 w-9 transition-all duration-200",
@@ -194,7 +197,12 @@ export function Header() {
                 <span className="inline-flex">
                   <PresetsDialog
                     trigger={
-                      <Button variant="ghost" size="icon" className="h-9 w-9">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Configuration Presets"
+                        className="h-9 w-9"
+                      >
                         <Sparkles className="h-4 w-4" />
                       </Button>
                     }
@@ -212,7 +220,7 @@ export function Header() {
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon" asChild className="h-9 w-9">
-                  <Link href="/themes">
+                  <Link href="/themes" aria-label="Browse Themes">
                     <Palette className="h-4 w-4" />
                   </Link>
                 </Button>
@@ -232,6 +240,7 @@ export function Header() {
                     href="https://github.com/imrajyavardhan12/spectre-ghostty-config"
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label="View Spectre on GitHub"
                   >
                     <Code2 className="h-4 w-4" />
                   </a>

--- a/src/components/preview/GhosttyPreview.tsx
+++ b/src/components/preview/GhosttyPreview.tsx
@@ -381,6 +381,7 @@ export function PreviewToggleButton({
   return (
     <Button
       onClick={onToggle}
+      aria-label={isOpen ? "Close Preview" : "Open Preview"}
       variant={isOpen ? "secondary" : "outline"}
       className={cn(
         "gap-2 shadow-lg transition-all duration-300",

--- a/src/components/settings/NumberInput.tsx
+++ b/src/components/settings/NumberInput.tsx
@@ -48,7 +48,7 @@ export function NumberInput({ option, showSlider = true }: NumberInputProps) {
         {useSlider ? (
           <>
             <Slider
-              id={option.id}
+              aria-label={`${option.name} slider`}
               value={[sliderValue]}
               onValueChange={([v]) => setValue(option.id, v)}
               min={option.min}
@@ -57,6 +57,7 @@ export function NumberInput({ option, showSlider = true }: NumberInputProps) {
               className="flex-1 max-w-xs"
             />
             <Input
+              id={option.id}
               type="number"
               value={value ?? option.default}
               onChange={(e) => setValue(option.id, parseFloat(e.target.value) || 0)}

--- a/src/components/settings/SettingWrapper.tsx
+++ b/src/components/settings/SettingWrapper.tsx
@@ -82,6 +82,7 @@ export function SettingWrapper({
                         href={`${GHOSTTY_DOCS_BASE_URL}#${id}`}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`View ${name} in Ghostty docs`}
                         className="text-muted-foreground hover:text-primary transition-colors"
                         onClick={(e) => e.stopPropagation()}
                       >
@@ -154,6 +155,7 @@ export function SettingWrapper({
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                    aria-label={`Reset ${name} to default`}
                     onClick={onReset}
                   >
                     <RotateCcw className="h-3.5 w-3.5" />

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -11,6 +11,8 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
@@ -53,6 +55,12 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
+          aria-label={
+            ariaLabel && _values.length > 1
+              ? `${ariaLabel} ${index + 1}`
+              : ariaLabel
+          }
+          aria-labelledby={ariaLabel ? undefined : ariaLabelledBy}
           className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}


### PR DESCRIPTION
## Summary

- add Playwright/Chromium coverage for landing → editor, edit/share/reopen, import/export, mobile navigation, preview retry, and remote-theme retry
- add axe-core WCAG A/AA checks for landing, desktop editor, and mobile editor
- run browser tests against the production build in required CI and upload reports on failure
- document local browser-test setup and include E2E checks in the release process

## User-facing fixes found through the tracer tests

- give icon-only actions, option reset controls, Ghostty docs links, and slider thumbs accessible names
- associate number labels with their numeric inputs while retaining labelled sliders
- prevent the mobile category strip from widening the entire page
- preserve Ghostty's extensionless `config` download filename in Chromium
- correct and prioritize the Buy Me a Coffee image dimensions

## Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test -- --run` — 313 passed
- `bun run build`
- `CI=1 bun run test:e2e` — 9 passed against `next start`
- CI workflow YAML parsed successfully

## Visual evidence

No intentional visual redesign. Mobile viewport and browser-download behavior are asserted directly in Playwright.
