### PR TITLE
fix: harden theme loading and preview lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 ### Changed
 
 - Bounded, de-duplicated, and cancellable theme loading, with the latest search prioritized ahead of stale queued work.
+- Kept canceled theme requests inside the six-request concurrency budget until they settle, with retry controls for individual download failures.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.
@@ -30,6 +31,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 - Prevented stale Ghostty preview initialization from attaching a terminal after the preview closes or a newer configuration replaces it, including cleanup of resources created by invalidated requests.
 - Added accessible names and status announcements to preview controls, loading, and failures.
+- Kept mobile navigation and minimize/restore controls accurately named in every responsive and preview state.
 - Added accessible names and state announcements to the theme browser.
 - Kept the theme browser header within the viewport on small screens.
 - Removed a stale Ghostty documentation anchor alias that caused the weekly schema drift check to fail after upstream restored the canonical `shell-integration` anchor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 ### Added
 
 - Added Playwright browser tests for the landing-to-editor path, import/export, config sharing, mobile navigation, preview recovery, theme-service recovery, and automated WCAG A/AA checks.
+- Added focused unit coverage for theme loading concurrency, prioritization, and cancellation.
 
 ### Changed
 
+- Bounded, de-duplicated, and cancellable theme loading, with the latest search prioritized ahead of stale queued work.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.
@@ -25,6 +27,8 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ### Fixed
 
+- Added accessible names and state announcements to the theme browser.
+- Kept the theme browser header within the viewport on small screens.
 - Removed a stale Ghostty documentation anchor alias that caused the weekly schema drift check to fail after upstream restored the canonical `shell-integration` anchor.
 - Added accessible names to editor actions, option reset controls, documentation links, and sliders.
 - Prevented the editor's mobile category strip from widening the page beyond the viewport.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 - Added Playwright browser tests for the landing-to-editor path, import/export, config sharing, mobile navigation, preview recovery, theme-service recovery, and automated WCAG A/AA checks.
 - Added focused unit coverage for theme loading concurrency, prioritization, and cancellation.
+- Added focused unit coverage for Ghostty preview lifecycle and supersession races.
 
 ### Changed
 
@@ -27,6 +28,8 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ### Fixed
 
+- Prevented stale Ghostty preview initialization from attaching a terminal after the preview closes or a newer configuration replaces it, including cleanup of resources created by invalidated requests.
+- Added accessible names and status announcements to preview controls, loading, and failures.
 - Added accessible names and state announcements to the theme browser.
 - Kept the theme browser header within the viewport on small screens.
 - Removed a stale Ghostty documentation anchor alias that caused the weekly schema drift check to fail after upstream restored the canonical `shell-integration` anchor.

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -2,6 +2,46 @@ import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 
 const WCAG_AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+const THEME_LIST_URL =
+  "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
+const DRACULA_THEME_URL =
+  "https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/ghostty/Dracula";
+const DRACULA_THEME_CONTENT = [
+  "background = #282a36",
+  "foreground = #f8f8f2",
+  "cursor-color = #f8f8f2",
+  "palette = 0=#21222c",
+  "palette = 1=#ff5555",
+  "palette = 2=#50fa7b",
+  "palette = 3=#f1fa8c",
+  "palette = 4=#bd93f9",
+  "palette = 5=#ff79c6",
+  "palette = 6=#8be9fd",
+  "palette = 7=#f8f8f2",
+].join("\n");
+
+async function mockThemeService(page: Page) {
+  await page.route(THEME_LIST_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          type: "file",
+          name: "Dracula",
+          download_url: DRACULA_THEME_URL,
+        },
+      ]),
+    })
+  );
+  await page.route(DRACULA_THEME_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body: DRACULA_THEME_CONTENT,
+    })
+  );
+}
 
 async function findAccessibilityViolations(page: Page) {
   // Let entrance animations settle so axe measures final colors and opacity.
@@ -46,4 +86,35 @@ test("the mobile editor has no automatically detectable WCAG A or AA violations"
   await expect(page.getByRole("heading", { name: "Fonts" })).toBeVisible();
 
   expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the theme browser has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await mockThemeService(page);
+
+  await page.goto("/themes");
+  await expect(page.getByRole("heading", { name: "Dracula" })).toBeVisible();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the mobile theme browser supports keyboard navigation without horizontal overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 844 });
+  await mockThemeService(page);
+  await page.goto("/themes");
+  await expect(page.getByRole("heading", { name: "Dracula" })).toBeVisible();
+
+  const search = page.getByRole("searchbox", { name: "Search themes" });
+  await search.focus();
+  await expect(search).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "All", exact: true })).toBeFocused();
+
+  const hasHorizontalPageOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth
+  );
+  expect(hasHorizontalPageOverflow).toBe(false);
 });

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -107,6 +107,10 @@ test("the mobile theme browser supports keyboard navigation without horizontal o
   await page.goto("/themes");
   await expect(page.getByRole("heading", { name: "Dracula" })).toBeVisible();
 
+  await expect(
+    page.getByRole("link", { name: "Spectre home" })
+  ).toBeVisible();
+
   const search = page.getByRole("searchbox", { name: "Search themes" });
   await search.focus();
   await expect(search).toBeFocused();
@@ -117,4 +121,5 @@ test("the mobile theme browser supports keyboard navigation without horizontal o
     () => document.documentElement.scrollWidth > window.innerWidth
   );
   expect(hasHorizontalPageOverflow).toBe(false);
+  expect(await findAccessibilityViolations(page)).toEqual([]);
 });

--- a/src/app/themes/page.tsx
+++ b/src/app/themes/page.tsx
@@ -16,12 +16,12 @@ export default function ThemesPage() {
       {/* Header - consistent with editor */}
       <header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-14 items-center justify-between px-4 sm:px-6">
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             <Link href="/" className="flex items-center gap-2 group">
               <Ghost className="h-6 w-6 text-primary transition-transform duration-150 group-hover:rotate-12" />
-              <span className="font-medium">Spectre</span>
+              <span className="hidden font-medium sm:inline">Spectre</span>
             </Link>
-            <span className="text-muted-foreground/50">/</span>
+            <span className="hidden text-muted-foreground/50 sm:inline">/</span>
             <div className="flex items-center gap-2">
               <Palette className="h-4 w-4 text-primary" />
               <span className="font-medium">Themes</span>
@@ -29,11 +29,17 @@ export default function ThemesPage() {
           </div>
 
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" asChild className="h-9 w-9">
+            <Button
+              variant="ghost"
+              size="icon"
+              asChild
+              className="hidden h-9 w-9 sm:inline-flex"
+            >
               <a
                 href="https://github.com/imrajyavardhan12/spectre-ghostty-config"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="View Spectre on GitHub"
               >
                 <Code2 className="h-4 w-4" />
               </a>
@@ -41,7 +47,7 @@ export default function ThemesPage() {
             <Button asChild>
               <Link href="/editor">
                 Open Editor
-                <ArrowRight className="h-4 w-4 ml-2" />
+                <ArrowRight className="hidden h-4 w-4 sm:inline sm:ml-2" />
               </Link>
             </Button>
           </div>
@@ -82,7 +88,7 @@ export default function ThemesPage() {
               href="https://github.com/mbadolato/iTerm2-Color-Schemes"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary hover:underline"
+              className="text-primary underline hover:no-underline"
             >
               iTerm2-Color-Schemes
             </a>

--- a/src/app/themes/page.tsx
+++ b/src/app/themes/page.tsx
@@ -17,7 +17,11 @@ export default function ThemesPage() {
       <header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-14 items-center justify-between px-4 sm:px-6">
           <div className="flex items-center gap-2 sm:gap-4">
-            <Link href="/" className="flex items-center gap-2 group">
+            <Link
+              href="/"
+              aria-label="Spectre home"
+              className="flex items-center gap-2 group"
+            >
               <Ghost className="h-6 w-6 text-primary transition-transform duration-150 group-hover:rotate-12" />
               <span className="hidden font-medium sm:inline">Spectre</span>
             </Link>

--- a/src/components/preview/GhosttyPreview.test.tsx
+++ b/src/components/preview/GhosttyPreview.test.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useConfigStore } from '@/lib/store/config-store';
 import { GhosttyPreview } from './GhosttyPreview';
 
@@ -121,6 +121,20 @@ describe('GhosttyPreview lifecycle', () => {
     rerender(<GhosttyPreview isOpen onToggle={vi.fn()} />);
     await waitFor(() => expect(mocks.terminalInstances).toHaveLength(2));
     expect(mocks.terminalInstances[1].open).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the minimize toggle name to match its current action', async () => {
+    render(<GhosttyPreview isOpen onToggle={vi.fn()} />);
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(1));
+
+    const minimizeToggle = screen.getAllByRole('button', {
+      name: 'Minimize preview',
+    })[0];
+    fireEvent.click(minimizeToggle);
+    expect(minimizeToggle).toHaveAccessibleName('Restore preview');
+
+    fireEvent.click(minimizeToggle);
+    expect(minimizeToggle).toHaveAccessibleName('Minimize preview');
   });
 
   it('lets a newer config creation supersede an in-flight request', async () => {

--- a/src/components/preview/GhosttyPreview.test.tsx
+++ b/src/components/preview/GhosttyPreview.test.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useConfigStore } from '@/lib/store/config-store';
+import { GhosttyPreview } from './GhosttyPreview';
+
+interface MockTerminalInstance {
+  options: Record<string, unknown>;
+  loadAddon: ReturnType<typeof vi.fn>;
+  open: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+interface MockFitAddonInstance {
+  fit: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+const mocks = vi.hoisted(() => ({
+  initGhosttyMock: vi.fn(),
+  terminalInstances: [] as MockTerminalInstance[],
+  fitAddonInstances: [] as MockFitAddonInstance[],
+  failNextOpen: false,
+}));
+
+vi.mock('@/lib/ghostty/init', () => ({
+  initGhostty: mocks.initGhosttyMock,
+}));
+
+vi.mock('ghostty-web', () => {
+  class MockTerminal {
+    options: Record<string, unknown>;
+    loadAddon = vi.fn();
+    open = vi.fn(() => {
+      if (mocks.failNextOpen) {
+        mocks.failNextOpen = false;
+        throw new Error('open failed');
+      }
+    });
+    write = vi.fn();
+    dispose = vi.fn();
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      mocks.terminalInstances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      mocks.fitAddonInstances.push(this);
+    }
+  }
+
+  return {
+    FitAddon: MockFitAddon,
+    Terminal: MockTerminal,
+    init: vi.fn(),
+  };
+});
+
+describe('GhosttyPreview lifecycle', () => {
+  beforeEach(() => {
+    mocks.initGhosttyMock.mockReset();
+    mocks.initGhosttyMock.mockResolvedValue(undefined);
+    mocks.terminalInstances.length = 0;
+    mocks.fitAddonInstances.length = 0;
+    mocks.failNextOpen = false;
+    act(() => {
+      useConfigStore.getState().resetAll();
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('does not attach a terminal when initialization finishes after close', async () => {
+    let resolveInitialization!: () => void;
+    mocks.initGhosttyMock.mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resolveInitialization = resolve;
+      })
+    );
+
+    const { rerender } = render(
+      <GhosttyPreview isOpen onToggle={vi.fn()} />
+    );
+    await waitFor(() => expect(mocks.initGhosttyMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('status')).toHaveTextContent('Loading Ghostty WASM...');
+
+    rerender(<GhosttyPreview isOpen={false} onToggle={vi.fn()} />);
+
+    await act(async () => {
+      resolveInitialization();
+    });
+
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(0));
+
+    rerender(<GhosttyPreview isOpen onToggle={vi.fn()} />);
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(1));
+    expect(mocks.terminalInstances[0].open).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the active terminal before creating a new one on reopen', async () => {
+    const { rerender } = render(
+      <GhosttyPreview isOpen onToggle={vi.fn()} />
+    );
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(1));
+
+    rerender(<GhosttyPreview isOpen={false} onToggle={vi.fn()} />);
+    expect(mocks.terminalInstances[0].dispose).toHaveBeenCalledTimes(1);
+    expect(mocks.fitAddonInstances[0].dispose).toHaveBeenCalledTimes(1);
+
+    rerender(<GhosttyPreview isOpen onToggle={vi.fn()} />);
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(2));
+    expect(mocks.terminalInstances[1].open).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a newer config creation supersede an in-flight request', async () => {
+    let resolveStaleCreation!: () => void;
+    mocks.initGhosttyMock
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () => new Promise<void>((resolve) => {
+          resolveStaleCreation = resolve;
+        })
+      )
+      .mockResolvedValueOnce(undefined);
+
+    render(<GhosttyPreview isOpen onToggle={vi.fn()} />);
+    await waitFor(() => expect(mocks.terminalInstances).toHaveLength(1));
+
+    act(() => {
+      useConfigStore.getState().setValue('font-size', 14);
+    });
+    await waitFor(
+      () => expect(mocks.initGhosttyMock).toHaveBeenCalledTimes(2),
+      { timeout: 1_000 }
+    );
+
+    act(() => {
+      useConfigStore.getState().setValue('font-size', 16);
+    });
+    await waitFor(
+      () => expect(mocks.terminalInstances).toHaveLength(2),
+      { timeout: 1_000 }
+    );
+
+    await act(async () => {
+      resolveStaleCreation();
+    });
+
+    expect(mocks.terminalInstances).toHaveLength(2);
+    expect(mocks.terminalInstances[0].dispose).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalInstances[1].options.fontSize).toBe(16);
+  });
+
+  it('disposes partially created resources and announces open failures', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.failNextOpen = true;
+
+    render(<GhosttyPreview isOpen onToggle={vi.fn()} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Failed to load preview');
+    expect(alert).toHaveTextContent('open failed');
+    expect(mocks.terminalInstances[0].dispose).toHaveBeenCalledTimes(1);
+    expect(mocks.fitAddonInstances[0].dispose).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/preview/GhosttyPreview.tsx
+++ b/src/components/preview/GhosttyPreview.tsx
@@ -318,7 +318,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
               </div>
               <div className="flex items-center gap-1">
                 <button
-                  aria-label="Minimize preview"
+                  aria-label={isMinimized ? "Restore preview" : "Minimize preview"}
                   onClick={() => setIsMinimized(!isMinimized)}
                   className="h-7 w-7 rounded-md border border-white/10 bg-white/5 hover:bg-white/10 transition-colors flex items-center justify-center"
                 >
@@ -356,7 +356,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
                     </span>
                   </button>
                   <button
-                    aria-label="Minimize preview"
+                    aria-label={isMinimized ? "Restore preview" : "Minimize preview"}
                     onClick={() => setIsMinimized(!isMinimized)}
                     className="w-3.5 h-3.5 rounded-full bg-[#febc2e] hover:bg-[#febc2e]/80 transition-colors flex items-center justify-center"
                   >

--- a/src/components/preview/GhosttyPreview.tsx
+++ b/src/components/preview/GhosttyPreview.tsx
@@ -13,7 +13,7 @@ import {
 import { generateDemoContent } from "@/lib/ghostty/demo-content";
 import { cn } from "@/lib/utils";
 import { detectClientOS, type ClientOS } from "@/lib/platform";
-import type { Terminal as GhosttyTerminal } from "ghostty-web";
+import type { ITerminalAddon, Terminal as GhosttyTerminal } from "ghostty-web";
 
 interface GhosttyPreviewProps {
   isOpen: boolean;
@@ -21,6 +21,7 @@ interface GhosttyPreviewProps {
 }
 
 type LoadingState = "idle" | "loading" | "ready" | "error";
+type FitAddonLike = ITerminalAddon & { fit: () => void };
 
 const DEBOUNCE_MS = 300;
 
@@ -32,26 +33,47 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
   
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<GhosttyTerminal | null>(null);
-  const fitAddonRef = useRef<{ fit: () => void; dispose: () => void } | null>(null);
+  const fitAddonRef = useRef<FitAddonLike | null>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const fitTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const creationRequestRef = useRef(0);
   const isInitializedRef = useRef(false);
   const configVersionRef = useRef(0);
   
   // Use selectors to properly subscribe to config changes
   const config = useConfigStore((state) => state.config);
   const appliedTheme = useConfigStore((state) => state.appliedTheme);
+  const configRef = useRef(config);
+  const appliedThemeRef = useRef(appliedTheme);
+  const lastCreatedConfigRef = useRef<typeof config | null>(null);
+  const lastCreatedThemeRef = useRef<string | null>(null);
+  configRef.current = config;
+  appliedThemeRef.current = appliedTheme;
 
-  const writeContent = useCallback(() => {
-    if (!terminalRef.current) return;
-    const term = terminalRef.current;
-    term.write("\x1bc");
-    term.write(generateDemoContent(appliedTheme, clientOS));
-    if (fitAddonRef.current) {
-      setTimeout(() => fitAddonRef.current?.fit(), 10);
-    }
-  }, [appliedTheme, clientOS]);
+  const writeContent = useCallback(
+    (term: GhosttyTerminal, fitAddon: FitAddonLike) => {
+      if (terminalRef.current !== term || fitAddonRef.current !== fitAddon) return;
+
+      term.write("\x1bc");
+      term.write(generateDemoContent(appliedThemeRef.current, clientOS));
+
+      if (fitTimerRef.current) {
+        clearTimeout(fitTimerRef.current);
+      }
+      fitTimerRef.current = setTimeout(() => {
+        if (terminalRef.current === term && fitAddonRef.current === fitAddon) {
+          fitAddon.fit();
+        }
+      }, 10);
+    },
+    [clientOS]
+  );
 
   const disposeTerminal = useCallback(() => {
+    if (fitTimerRef.current) {
+      clearTimeout(fitTimerRef.current);
+      fitTimerRef.current = null;
+    }
     if (terminalRef.current) {
       terminalRef.current.dispose();
       terminalRef.current = null;
@@ -67,49 +89,95 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
   }, []);
 
   const createTerminal = useCallback(async (showLoading = true) => {
-    if (!containerRef.current) return;
+    if (!containerRef.current || !isOpen) return;
+
+    const requestId = ++creationRequestRef.current;
+    const isCurrentRequest = () =>
+      requestId === creationRequestRef.current &&
+      isOpen &&
+      containerRef.current !== null;
 
     if (showLoading) {
       setLoadingState("loading");
     }
     setError(null);
 
+    let createdTerm: GhosttyTerminal | null = null;
+    let createdFitAddon: FitAddonLike | null = null;
+    const disposeCreatedResources = () => {
+      const term = createdTerm;
+      const fitAddon = createdFitAddon;
+      createdTerm = null;
+      createdFitAddon = null;
+      term?.dispose();
+      fitAddon?.dispose();
+    };
+
     try {
       await initGhostty();
+      if (!isCurrentRequest()) return;
 
       const { Terminal, FitAddon } = await import("ghostty-web");
+      if (!isCurrentRequest()) return;
 
-      // Dispose existing terminal first
+      // Dispose existing terminal first. A request id prevents an older
+      // in-flight initialization from attaching itself after a close or a
+      // newer config change.
       disposeTerminal();
 
-      const options = mapConfigToTerminalOptions(config);
+      const configForTerminal = configRef.current;
+      const options = mapConfigToTerminalOptions(configForTerminal);
       const defaultTheme = getDefaultTheme();
-      const userTheme = mapConfigToTheme(config);
+      const userTheme = mapConfigToTheme(configForTerminal);
 
       options.theme = { ...defaultTheme, ...userTheme };
 
-      const term = new Terminal(options);
-      const fitAddon = new FitAddon();
+      createdTerm = new Terminal(options);
+      createdFitAddon = new FitAddon();
 
-      term.loadAddon(fitAddon);
-      term.open(containerRef.current);
+      createdTerm.loadAddon(createdFitAddon);
+      const container = containerRef.current;
+      if (!container || !isCurrentRequest()) {
+        disposeCreatedResources();
+        return;
+      }
+      createdTerm.open(container);
 
-      terminalRef.current = term;
-      fitAddonRef.current = fitAddon;
+      if (!isCurrentRequest()) {
+        disposeCreatedResources();
+        return;
+      }
+
+      terminalRef.current = createdTerm;
+      fitAddonRef.current = createdFitAddon;
       isInitializedRef.current = true;
-      
+      lastCreatedConfigRef.current = configForTerminal;
+      lastCreatedThemeRef.current = appliedThemeRef.current;
+
       setTimeout(() => {
-        fitAddon.fit();
-        writeContent();
+        if (!isCurrentRequest() || terminalRef.current !== createdTerm) return;
+        createdFitAddon?.fit();
+        if (createdTerm && createdFitAddon) {
+          writeContent(createdTerm, createdFitAddon);
+        }
       }, 50);
 
       setLoadingState("ready");
     } catch (err) {
+      // A stale request may have been invalidated by closing the preview or
+      // starting another initialization. It must not overwrite the current
+      // UI state, but any locally-created resources still need cleanup.
+      if (!isCurrentRequest()) {
+        disposeCreatedResources();
+        return;
+      }
+
+      disposeCreatedResources();
       console.error("Failed to initialize Ghostty preview:", err);
       setError(err instanceof Error ? err.message : "Failed to load preview");
       setLoadingState("error");
     }
-  }, [config, writeContent, disposeTerminal]);
+  }, [disposeTerminal, isOpen, writeContent]);
 
   // Initial terminal creation when preview opens
   useEffect(() => {
@@ -120,25 +188,35 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
 
   // Debounced recreation when config changes (after initial load)
   useEffect(() => {
-    // Skip if not open or not yet initialized
-    if (!isOpen || !isInitializedRef.current || loadingState !== "ready") {
+    // Skip if not open or not yet initialized. Comparing against the last
+    // successful creation also avoids recreating the terminal merely because
+    // the initial loading state changed to ready.
+    if (
+      !isOpen ||
+      !isInitializedRef.current ||
+      loadingState !== "ready" ||
+      (lastCreatedConfigRef.current === configRef.current &&
+        lastCreatedThemeRef.current === appliedThemeRef.current)
+    ) {
       return;
     }
 
-    // Increment config version
     configVersionRef.current += 1;
     const currentVersion = configVersionRef.current;
 
-    // Clear existing timer
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }
 
-    // Debounce the terminal recreation
     debounceTimerRef.current = setTimeout(() => {
-      // Only recreate if this is still the latest config version
-      if (currentVersion === configVersionRef.current) {
-        createTerminal(false);
+      // Only recreate if this is still the latest config version and the
+      // pending request is not already current.
+      if (
+        currentVersion === configVersionRef.current &&
+        (lastCreatedConfigRef.current !== configRef.current ||
+          lastCreatedThemeRef.current !== appliedThemeRef.current)
+      ) {
+        void createTerminal(false);
       }
     }, DEBOUNCE_MS);
 
@@ -152,6 +230,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      creationRequestRef.current += 1;
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
@@ -159,13 +238,21 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
     };
   }, [disposeTerminal]);
 
-  // Reset terminal when closing so it reinitializes on reopen
+  // Reset terminal when closing so it reinitializes on reopen. Invalidate
+  // pending initialization before disposing, otherwise a late WASM import
+  // could attach a terminal to a container that is no longer mounted.
   useEffect(() => {
-    if (!isOpen && isInitializedRef.current) {
+    if (!isOpen) {
+      creationRequestRef.current += 1;
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
       disposeTerminal();
       setLoadingState("idle");
       isInitializedRef.current = false;
       configVersionRef.current = 0;
+      lastCreatedConfigRef.current = null;
+      lastCreatedThemeRef.current = null;
     }
   }, [isOpen, disposeTerminal]);
 
@@ -260,6 +347,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
               <div className="flex items-center gap-2">
                 <div className="flex gap-2 group/buttons">
                   <button
+                    aria-label="Close preview"
                     onClick={onToggle}
                     className="w-3.5 h-3.5 rounded-full bg-[#ff5f57] hover:bg-[#ff5f57]/80 transition-colors flex items-center justify-center"
                   >
@@ -268,6 +356,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
                     </span>
                   </button>
                   <button
+                    aria-label="Minimize preview"
                     onClick={() => setIsMinimized(!isMinimized)}
                     className="w-3.5 h-3.5 rounded-full bg-[#febc2e] hover:bg-[#febc2e]/80 transition-colors flex items-center justify-center"
                   >
@@ -279,6 +368,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
                     </span>
                   </button>
                   <button
+                    aria-label="Restore preview"
                     onClick={() => setIsMinimized(false)}
                     className="w-3.5 h-3.5 rounded-full bg-[#28c840] hover:bg-[#28c840]/80 transition-colors flex items-center justify-center"
                   >
@@ -298,6 +388,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
                   size="icon"
                   className="h-6 w-6 hover:bg-white/10"
                   onClick={() => setIsMinimized(!isMinimized)}
+                  aria-label={isMinimized ? "Restore preview" : "Minimize preview"}
                 >
                   {isMinimized ? (
                     <Maximize2 className="h-3 w-3" style={{ color: foreground }} />
@@ -319,9 +410,15 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
           }}
         >
           {loadingState === "loading" && (
-            <div className="absolute inset-0 flex items-center justify-center">
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="absolute inset-0 flex items-center justify-center"
+            >
               <div className="flex flex-col items-center gap-3">
                 <Loader2
+                  aria-hidden="true"
                   className="h-8 w-8 animate-spin"
                   style={{ color: foreground }}
                 />
@@ -333,9 +430,13 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
           )}
 
           {loadingState === "error" && (
-            <div className="absolute inset-0 flex items-center justify-center">
+            <div
+              role="alert"
+              aria-atomic="true"
+              className="absolute inset-0 flex items-center justify-center"
+            >
               <div className="flex flex-col items-center gap-3 text-center px-4">
-                <AlertCircle className="h-8 w-8 text-red-500" />
+                <AlertCircle aria-hidden="true" className="h-8 w-8 text-red-500" />
                 <span className="text-sm" style={{ color: foreground }}>
                   Failed to load preview
                 </span>
@@ -346,8 +447,7 @@ export function GhosttyPreview({ isOpen, onToggle }: GhosttyPreviewProps) {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    setLoadingState("idle");
-                    createTerminal(true);
+                    void createTerminal(true);
                   }}
                 >
                   Retry

--- a/src/components/themes/ThemeBrowser.test.tsx
+++ b/src/components/themes/ThemeBrowser.test.tsx
@@ -134,6 +134,55 @@ describe('ThemeBrowser loading lifecycle', () => {
     expect(fetchThemeMock.mock.calls[6][0]).toBe('Target Theme');
   });
 
+  it('keeps concurrency slots occupied until aborted requests settle', async () => {
+    const oldNames = Array.from({ length: 6 }, (_, index) => `Old Theme ${index}`);
+    const names = [...oldNames, 'New Theme'];
+    const resolvers = new Map<string, () => void>();
+    const signals = new Map<string, AbortSignal>();
+
+    fetchThemeListMock.mockResolvedValue(createThemeList(names));
+    fetchThemeMock.mockImplementation(
+      (name: string, options: { signal: AbortSignal }) => {
+        signals.set(name, options.signal);
+        if (name === 'New Theme') {
+          return Promise.resolve(createTheme(name));
+        }
+        return new Promise<void>((resolve) => {
+          resolvers.set(name, resolve);
+        }).then(() => createTheme(name));
+      }
+    );
+
+    render(<ThemeBrowser />);
+    await waitFor(() => {
+      expect(screen.getByText('0 of 7 themes loaded')).toBeInTheDocument();
+    });
+    const search = screen.getByRole('searchbox', { name: 'Search themes' });
+    fireEvent.change(search, { target: { value: 'Old' } });
+    await waitFor(
+      () => expect(fetchThemeMock).toHaveBeenCalledTimes(6),
+      { timeout: 1_000 }
+    );
+
+    fireEvent.change(search, { target: { value: 'New' } });
+    await waitFor(() => {
+      expect(oldNames.every((name) => signals.get(name)?.aborted)).toBe(true);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    // The replacement remains queued because the six aborted promises have
+    // deliberately not settled yet.
+    expect(fetchThemeMock).toHaveBeenCalledTimes(6);
+
+    await act(async () => {
+      resolvers.get(oldNames[0])?.();
+    });
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(7));
+    expect(fetchThemeMock.mock.calls[6][0]).toBe('New Theme');
+  });
+
   it('aborts work that was only needed by a superseded search', async () => {
     let oldSearchSignal: AbortSignal | undefined;
     fetchThemeListMock.mockResolvedValue(
@@ -176,6 +225,29 @@ describe('ThemeBrowser loading lifecycle', () => {
       { timeout: 1_000 }
     );
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Theme' })).toBeInTheDocument());
+    expect(screen.queryByText(/failed to load/i)).not.toBeInTheDocument();
+  });
+
+  it('reports individual download failures and retries them', async () => {
+    fetchThemeListMock.mockResolvedValue(createThemeList(['Featured']));
+    fetchThemeMock
+      .mockRejectedValueOnce(new Error('theme service unavailable'))
+      .mockResolvedValueOnce(createTheme('Featured'));
+
+    render(<ThemeBrowser />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 theme failed to load.')).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Retry failed theme' })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('1 of 1 themes loaded')).toBeInTheDocument();
+      expect(screen.queryByText('1 theme failed to load.')).not.toBeInTheDocument();
+    });
+    expect(fetchThemeMock).toHaveBeenCalledTimes(2);
   });
 
   it('aborts the theme request when the browser unmounts', async () => {

--- a/src/components/themes/ThemeBrowser.test.tsx
+++ b/src/components/themes/ThemeBrowser.test.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { StrictMode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeBrowser } from './ThemeBrowser';
+
+const { fetchThemeListMock, fetchThemeMock } = vi.hoisted(() => ({
+  fetchThemeListMock: vi.fn(),
+  fetchThemeMock: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/themes', () => ({
+  FEATURED_THEMES: ['Featured'],
+  categorizeTheme: (theme: { colors: { background: string } }) =>
+    theme.colors.background === '#ffffff' ? 'light' : 'dark',
+  fetchThemeList: fetchThemeListMock,
+  fetchTheme: fetchThemeMock,
+  themeToConfig: () => ({ background: '#000000', foreground: '#ffffff' }),
+}));
+
+vi.mock('./ThemeCard', () => ({
+  ThemeCard: ({ theme }: { theme: { name: string } }) => (
+    <button type="button">{theme.name}</button>
+  ),
+  ThemeCardSkeleton: () => <div data-testid="theme-skeleton" />,
+}));
+
+function createTheme(name: string) {
+  return {
+    name,
+    colors: {
+      background: '#000000',
+      foreground: '#ffffff',
+      palette: Array(16).fill(''),
+    },
+    raw: '',
+  };
+}
+
+function createThemeList(names: string[]) {
+  return names.map((name) => ({
+    name,
+    downloadUrl: `https://example.test/${encodeURIComponent(name)}`,
+  }));
+}
+
+describe('ThemeBrowser loading lifecycle', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('deduplicates overlapping loads and limits theme fetches to six at a time', async () => {
+    const names = ['Featured', ...Array.from({ length: 10 }, (_, index) => `Theme ${index}`)];
+    const resolvers = new Map<string, () => void>();
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+
+    fetchThemeListMock.mockResolvedValue(createThemeList(names));
+    fetchThemeMock.mockImplementation((name: string) => {
+      return new Promise<void>((resolve) => {
+        activeRequests += 1;
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+        resolvers.set(name, () => {
+          activeRequests -= 1;
+          resolve();
+        });
+      }).then(() => createTheme(name));
+    });
+
+    render(<ThemeBrowser />);
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledWith(
+      'Featured',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    ));
+
+    // Request all themes while Featured is still in flight. The scheduler can
+    // fill the remaining slots, but it must reuse Featured's existing task.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(6));
+    expect(maxActiveRequests).toBe(6);
+
+    const firstWave = fetchThemeMock.mock.calls.map(([name]) => name as string);
+    await act(async () => {
+      firstWave.forEach((name) => resolvers.get(name)?.());
+    });
+
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(11));
+    expect(maxActiveRequests).toBe(6);
+
+    const requestedNames = fetchThemeMock.mock.calls.map(([name]) => name as string);
+    await act(async () => {
+      requestedNames.slice(6).forEach((name) => resolvers.get(name)?.());
+    });
+
+    await waitFor(() => expect(screen.getByText('11 of 11 themes loaded')).toBeInTheDocument());
+    expect(requestedNames).toHaveLength(new Set(requestedNames).size);
+    expect(requestedNames).toEqual(names);
+  });
+
+  it('prioritizes the latest search over older queued filter work', async () => {
+    const names = [
+      'Featured',
+      ...Array.from({ length: 10 }, (_, index) => `Theme ${index}`),
+      'Target Theme',
+    ];
+    const resolvers = new Map<string, () => void>();
+
+    fetchThemeListMock.mockResolvedValue(createThemeList(names));
+    fetchThemeMock.mockImplementation((name: string) => {
+      return new Promise<void>((resolve) => {
+        resolvers.set(name, resolve);
+      }).then(() => createTheme(name));
+    });
+
+    render(<ThemeBrowser />);
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(6));
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search themes' }), {
+      target: { value: 'Target' },
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    await act(async () => {
+      resolvers.get('Featured')?.();
+    });
+
+    await waitFor(() => expect(fetchThemeMock).toHaveBeenCalledTimes(7));
+    expect(fetchThemeMock.mock.calls[6][0]).toBe('Target Theme');
+  });
+
+  it('aborts work that was only needed by a superseded search', async () => {
+    let oldSearchSignal: AbortSignal | undefined;
+    fetchThemeListMock.mockResolvedValue(
+      createThemeList(['Featured', 'Old Theme', 'New Theme'])
+    );
+    fetchThemeMock.mockImplementation(
+      (name: string, options: { signal?: AbortSignal }) => {
+        if (name === 'Old Theme') {
+          oldSearchSignal = options.signal;
+          return new Promise((_resolve, reject) => {
+            options.signal?.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          });
+        }
+        return Promise.resolve(createTheme(name));
+      }
+    );
+
+    render(<ThemeBrowser />);
+    await waitFor(() => expect(screen.getByText('1 of 3 themes loaded')).toBeInTheDocument());
+
+    const search = screen.getByRole('searchbox', { name: 'Search themes' });
+    fireEvent.change(search, { target: { value: 'Old' } });
+    await waitFor(
+      () => expect(fetchThemeMock).toHaveBeenCalledWith(
+        'Old Theme',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      ),
+      { timeout: 1_000 }
+    );
+
+    fireEvent.change(search, { target: { value: 'New' } });
+    await waitFor(() => expect(oldSearchSignal?.aborted).toBe(true));
+    await waitFor(
+      () => expect(fetchThemeMock).toHaveBeenCalledWith(
+        'New Theme',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      ),
+      { timeout: 1_000 }
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Theme' })).toBeInTheDocument());
+  });
+
+  it('aborts the theme request when the browser unmounts', async () => {
+    let requestSignal: AbortSignal | undefined;
+    fetchThemeListMock.mockResolvedValue(createThemeList(['Featured']));
+    fetchThemeMock.mockImplementation((_name: string, options: { signal?: AbortSignal }) => {
+      requestSignal = options.signal;
+      return new Promise(() => undefined);
+    });
+
+    const { unmount } = render(<ThemeBrowser />);
+    await waitFor(() => expect(requestSignal).toBeDefined());
+
+    unmount();
+
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it('aborts the replayed list request and avoids duplicate theme downloads in Strict Mode', async () => {
+    fetchThemeListMock.mockResolvedValue(createThemeList(['Featured']));
+    fetchThemeMock.mockResolvedValue(createTheme('Featured'));
+
+    render(
+      <StrictMode>
+        <ThemeBrowser />
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(screen.getByText('1 of 1 themes loaded')).toBeInTheDocument());
+    expect(fetchThemeListMock).toHaveBeenCalledTimes(2);
+    const firstSignal = fetchThemeListMock.mock.calls[0][0].signal as AbortSignal;
+    const currentSignal = fetchThemeListMock.mock.calls[1][0].signal as AbortSignal;
+    expect(firstSignal.aborted).toBe(true);
+    expect(currentSignal.aborted).toBe(false);
+    expect(fetchThemeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/themes/ThemeBrowser.tsx
+++ b/src/components/themes/ThemeBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Search, Palette, Moon, Sun, Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,23 @@ import { useConfigStore } from "@/lib/store/config-store";
 
 type FilterType = "all" | "dark" | "light" | "featured";
 
+const THEME_FETCH_CONCURRENCY = 6;
+const SEARCH_LOAD_DEBOUNCE_MS = 200;
+
+type ThemeLoadSource = "featured" | "filter" | "manual" | "search";
+type ThemeLoadStatus = "queued" | "active";
+
+interface ThemeLoadTask {
+  name: string;
+  priority: number;
+  order: number;
+  status: ThemeLoadStatus;
+  priorities: Map<ThemeLoadSource, number>;
+  controller: AbortController;
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
 export function ThemeBrowser() {
   const [themeList, setThemeList] = useState<ThemeListItem[]>([]);
   const [loadedThemes, setLoadedThemes] = useState<Map<string, Theme>>(new Map());
@@ -29,34 +46,196 @@ export function ThemeBrowser() {
   const [searchQuery, setSearchQuery] = useState("");
   const [filter, setFilter] = useState<FilterType>("featured");
   const [appliedTheme, setAppliedTheme] = useState<string | null>(null);
+  const loadedThemesRef = useRef(loadedThemes);
+  const pendingThemeLoadsRef = useRef(new Map<string, ThemeLoadTask>());
+  const queuedThemeLoadsRef = useRef<ThemeLoadTask[]>([]);
+  const activeThemeLoadsRef = useRef(0);
+  const themeLoadOrderRef = useRef(0);
+  const searchPriorityRef = useRef(0);
+  const drainThemeQueueRef = useRef<() => void>(() => undefined);
+  const themeListAbortControllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
   
   // Use selectors to properly subscribe to config changes
   const config = useConfigStore((state) => state.config);
   const loadConfig = useConfigStore((state) => state.loadConfig);
 
-  // Load a batch of themes
-  const loadThemeBatch = useCallback(async (names: string[]) => {
-    setLoadingMore(true);
-    const results = await Promise.allSettled(names.map(fetchTheme));
-    
-    setLoadedThemes((prev) => {
-      const next = new Map(prev);
-      results.forEach((result, index) => {
-        if (result.status === "fulfilled" && !prev.has(names[index])) {
-          next.set(names[index], result.value);
-        }
-      });
-      return next;
-    });
-    setLoadingMore(false);
+  const updateLoadingMore = useCallback(() => {
+    if (isMountedRef.current) {
+      setLoadingMore(pendingThemeLoadsRef.current.size > 0);
+    }
   }, []);
+
+  const detachThemeLoad = useCallback(
+    (task: ThemeLoadTask) => {
+      if (pendingThemeLoadsRef.current.get(task.name) !== task) return;
+
+      pendingThemeLoadsRef.current.delete(task.name);
+      if (task.status === "active") {
+        activeThemeLoadsRef.current = Math.max(0, activeThemeLoadsRef.current - 1);
+      } else {
+        queuedThemeLoadsRef.current = queuedThemeLoadsRef.current.filter(
+          (queuedTask) => queuedTask !== task
+        );
+      }
+
+      task.controller.abort();
+      task.resolve();
+      updateLoadingMore();
+    },
+    [updateLoadingMore]
+  );
+
+  const drainThemeQueue = useCallback(() => {
+    if (!isMountedRef.current) return;
+
+    queuedThemeLoadsRef.current.sort(
+      (a, b) => b.priority - a.priority || a.order - b.order
+    );
+
+    while (
+      activeThemeLoadsRef.current < THEME_FETCH_CONCURRENCY &&
+      queuedThemeLoadsRef.current.length > 0
+    ) {
+      const task = queuedThemeLoadsRef.current.shift();
+      if (
+        !task ||
+        task.status !== "queued" ||
+        pendingThemeLoadsRef.current.get(task.name) !== task
+      ) {
+        continue;
+      }
+
+      task.status = "active";
+      activeThemeLoadsRef.current += 1;
+
+      void fetchTheme(task.name, { signal: task.controller.signal })
+        .then((theme) => {
+          if (
+            !isMountedRef.current ||
+            task.controller.signal.aborted ||
+            pendingThemeLoadsRef.current.get(task.name) !== task
+          ) {
+            return;
+          }
+
+          const next = new Map(loadedThemesRef.current);
+          next.set(task.name, theme);
+          loadedThemesRef.current = next;
+          setLoadedThemes(next);
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          if (pendingThemeLoadsRef.current.get(task.name) !== task) return;
+
+          pendingThemeLoadsRef.current.delete(task.name);
+          activeThemeLoadsRef.current = Math.max(
+            0,
+            activeThemeLoadsRef.current - 1
+          );
+          task.resolve();
+          updateLoadingMore();
+          drainThemeQueueRef.current();
+        });
+    }
+  }, [updateLoadingMore]);
+  drainThemeQueueRef.current = drainThemeQueue;
+
+  // Schedule per-theme work so overlapping UI requests share one fetch. Newer
+  // searches receive a higher priority and can move already-queued names ahead
+  // of stale work without discarding themes that have already loaded.
+  const loadThemeBatch = useCallback(
+    (
+      names: string[],
+      source: ThemeLoadSource,
+      priority = 0
+    ): Promise<void> => {
+      const promises = [...new Set(names)].map((name) => {
+        if (loadedThemesRef.current.has(name)) {
+          return Promise.resolve();
+        }
+
+        const pendingTask = pendingThemeLoadsRef.current.get(name);
+        if (pendingTask) {
+          pendingTask.priorities.set(source, priority);
+          pendingTask.priority = Math.max(...pendingTask.priorities.values());
+          return pendingTask.promise;
+        }
+
+        let resolveTask: () => void = () => undefined;
+        const promise = new Promise<void>((resolve) => {
+          resolveTask = resolve;
+        });
+        const priorities = new Map<ThemeLoadSource, number>([[source, priority]]);
+        const task: ThemeLoadTask = {
+          name,
+          priority,
+          order: themeLoadOrderRef.current++,
+          status: "queued",
+          priorities,
+          controller: new AbortController(),
+          promise,
+          resolve: resolveTask,
+        };
+
+        pendingThemeLoadsRef.current.set(name, task);
+        queuedThemeLoadsRef.current.push(task);
+        return promise;
+      });
+
+      updateLoadingMore();
+      drainThemeQueueRef.current();
+      return Promise.all(promises).then(() => undefined);
+    },
+    [updateLoadingMore]
+  );
+
+  const releaseThemeLoadSource = useCallback(
+    (source: ThemeLoadSource) => {
+      for (const task of [...pendingThemeLoadsRef.current.values()]) {
+        if (!task.priorities.delete(source)) continue;
+
+        if (task.priorities.size === 0) {
+          detachThemeLoad(task);
+        } else {
+          task.priority = Math.max(...task.priorities.values());
+        }
+      }
+
+      drainThemeQueueRef.current();
+    },
+    [detachThemeLoad]
+  );
+
+  // Cancel list and theme requests when leaving the browser. Resolving queued
+  // task promises also lets any awaiting effects finish without retaining the
+  // unmounted component.
+  useEffect(() => {
+    isMountedRef.current = true;
+    const controller = new AbortController();
+    const pendingThemeLoads = pendingThemeLoadsRef.current;
+    themeListAbortControllerRef.current = controller;
+
+    return () => {
+      isMountedRef.current = false;
+      controller.abort();
+      for (const task of [...pendingThemeLoads.values()]) {
+        detachThemeLoad(task);
+      }
+      queuedThemeLoadsRef.current = [];
+      activeThemeLoadsRef.current = 0;
+    };
+  }, [detachThemeLoad]);
 
   // Fetch theme list on mount
   useEffect(() => {
+    const signal = themeListAbortControllerRef.current?.signal;
+
     async function loadThemeList() {
       try {
         setLoading(true);
-        const list = await fetchThemeList();
+        const list = await fetchThemeList({ signal });
+        if (!isMountedRef.current || signal?.aborted) return;
         setThemeList(list);
         
         // Load featured themes first
@@ -65,15 +244,18 @@ export function ThemeBrowser() {
           .map((t) => t.name)
           .slice(0, 12);
         
-        await loadThemeBatch(featuredNames);
+        await loadThemeBatch(featuredNames, "featured");
       } catch (err) {
+        if (!isMountedRef.current || signal?.aborted) return;
         setError(err instanceof Error ? err.message : "Failed to load themes");
       } finally {
-        setLoading(false);
+        if (isMountedRef.current && !signal?.aborted) {
+          setLoading(false);
+        }
       }
     }
     
-    loadThemeList();
+    void loadThemeList();
   }, [loadThemeBatch]);
 
   // Filter and search themes
@@ -93,7 +275,9 @@ export function ThemeBrowser() {
       themes = themes.filter((t) => categorizeTheme(t) === "dark");
     } else if (filter === "light") {
       themes = themes.filter((t) => categorizeTheme(t) === "light");
-    } else if (filter === "featured") {
+    } else if (filter === "featured" && !searchQuery) {
+      // Searching should cover the complete upstream list even though the
+      // browser defaults to Featured before the user enters a query.
       themes = themes.filter((t) => FEATURED_THEMES.includes(t.name));
     }
 
@@ -109,30 +293,49 @@ export function ThemeBrowser() {
     return themes;
   }, [loadedThemes, searchQuery, filter]);
 
-  // Auto-load all themes when a non-featured filter is selected
+  // Auto-load all themes when a non-featured filter is selected. Switching
+  // back to Featured releases filter-only work while retaining shared search
+  // and manual requests.
+  const shouldLoadAllForFilter = filter !== "featured";
   useEffect(() => {
-    if (filter !== "featured" && themeList.length > 0 && loadedThemes.size < themeList.length) {
-      const allNames = themeList.map((t) => t.name);
-      loadThemeBatch(allNames);
+    if (!shouldLoadAllForFilter) {
+      releaseThemeLoadSource("filter");
+      return;
     }
-  }, [filter, themeList, loadedThemes.size, loadThemeBatch]);
 
-  // Load more themes when searching
+    if (themeList.length > 0) {
+      void loadThemeBatch(
+        themeList.map((theme) => theme.name),
+        "filter"
+      );
+    }
+  }, [shouldLoadAllForFilter, themeList, loadThemeBatch, releaseThemeLoadSource]);
+
+  // Debounce search requests and immediately cancel queued or in-flight work
+  // that was only needed by the previous query. A monotonically increasing
+  // priority lets the latest query jump ahead of older shared work.
   useEffect(() => {
+    releaseThemeLoadSource("search");
     if (!searchQuery) return;
-    
-    const matchingNames = themeList
-      .filter((t) => t.name.toLowerCase().includes(searchQuery.toLowerCase()))
-      .map((t) => t.name)
-      .slice(0, 20);
-    
-    loadThemeBatch(matchingNames);
-  }, [searchQuery, themeList, loadThemeBatch]);
+
+    const priority = ++searchPriorityRef.current;
+    const timeoutId = window.setTimeout(() => {
+      const query = searchQuery.toLowerCase();
+      const matchingNames = themeList
+        .filter((theme) => theme.name.toLowerCase().includes(query))
+        .map((theme) => theme.name)
+        .slice(0, 20);
+
+      void loadThemeBatch(matchingNames, "search", priority);
+    }, SEARCH_LOAD_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchQuery, themeList, loadThemeBatch, releaseThemeLoadSource]);
 
   // Load all themes button
   const handleLoadAll = async () => {
     const allNames = themeList.map((t) => t.name);
-    await loadThemeBatch(allNames);
+    await loadThemeBatch(allNames, "manual");
   };
 
   // Apply theme
@@ -164,7 +367,10 @@ export function ThemeBrowser() {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div
+        role="alert"
+        className="flex flex-col items-center justify-center py-16 text-center"
+      >
         <div className="w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mb-4">
           <Palette className="h-8 w-8 text-destructive" />
         </div>
@@ -180,8 +386,16 @@ export function ThemeBrowser() {
       {/* Search and filters */}
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <label htmlFor="theme-search" className="sr-only">
+            Search themes
+          </label>
+          <Search
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+          />
           <Input
+            id="theme-search"
+            type="search"
             placeholder="Search themes..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -189,13 +403,18 @@ export function ThemeBrowser() {
           />
         </div>
         
-        <div className="flex gap-2">
+        <div
+          className="grid grid-cols-2 gap-2 sm:flex"
+          role="group"
+          aria-label="Filter themes"
+        >
           {filterButtons.map((btn) => (
             <Button
               key={btn.value}
               variant={filter === btn.value ? "default" : "outline"}
               size="sm"
               onClick={() => setFilter(btn.value)}
+              aria-pressed={filter === btn.value}
               className="gap-1.5"
             >
               {btn.icon}
@@ -206,7 +425,10 @@ export function ThemeBrowser() {
       </div>
 
       {/* Stats */}
-      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+      <div
+        className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground"
+        aria-live="polite"
+      >
         <span>
           {loadedThemes.size} of {themeList.length} themes loaded
         </span>
@@ -238,7 +460,11 @@ export function ThemeBrowser() {
 
       {/* Theme grid */}
       {loading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+          aria-busy="true"
+          aria-label="Loading themes"
+        >
           {Array(8)
             .fill(0)
             .map((_, i) => (
@@ -246,7 +472,11 @@ export function ThemeBrowser() {
             ))}
         </div>
       ) : filteredThemes.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <div
+          id="theme-results"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+          aria-busy={loadingMore}
+        >
           {filteredThemes.map((theme) => (
             <ThemeCard
               key={theme.name}
@@ -270,8 +500,15 @@ export function ThemeBrowser() {
 
       {/* Load more indicator */}
       {loadingMore && (
-        <div className="flex justify-center py-4">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <div
+          className="flex justify-center py-4"
+          role="status"
+          aria-label="Loading more themes"
+        >
+          <Loader2
+            aria-hidden="true"
+            className="h-6 w-6 animate-spin text-muted-foreground"
+          />
         </div>
       )}
     </div>

--- a/src/components/themes/ThemeBrowser.tsx
+++ b/src/components/themes/ThemeBrowser.tsx
@@ -30,7 +30,9 @@ interface ThemeLoadTask {
   name: string;
   priority: number;
   order: number;
+  generation: number;
   status: ThemeLoadStatus;
+  occupiesSlot: boolean;
   priorities: Map<ThemeLoadSource, number>;
   controller: AbortController;
   promise: Promise<void>;
@@ -46,11 +48,15 @@ export function ThemeBrowser() {
   const [searchQuery, setSearchQuery] = useState("");
   const [filter, setFilter] = useState<FilterType>("featured");
   const [appliedTheme, setAppliedTheme] = useState<string | null>(null);
+  const [failedThemeNames, setFailedThemeNames] = useState<Set<string>>(
+    new Set()
+  );
   const loadedThemesRef = useRef(loadedThemes);
   const pendingThemeLoadsRef = useRef(new Map<string, ThemeLoadTask>());
   const queuedThemeLoadsRef = useRef<ThemeLoadTask[]>([]);
   const activeThemeLoadsRef = useRef(0);
   const themeLoadOrderRef = useRef(0);
+  const themeLoadGenerationRef = useRef(0);
   const searchPriorityRef = useRef(0);
   const drainThemeQueueRef = useRef<() => void>(() => undefined);
   const themeListAbortControllerRef = useRef<AbortController | null>(null);
@@ -66,19 +72,32 @@ export function ThemeBrowser() {
     }
   }, []);
 
+  const releaseThemeLoadSlot = useCallback((task: ThemeLoadTask) => {
+    if (!task.occupiesSlot) return;
+
+    task.occupiesSlot = false;
+    if (task.generation === themeLoadGenerationRef.current) {
+      activeThemeLoadsRef.current = Math.max(
+        0,
+        activeThemeLoadsRef.current - 1
+      );
+    }
+  }, []);
+
   const detachThemeLoad = useCallback(
     (task: ThemeLoadTask) => {
       if (pendingThemeLoadsRef.current.get(task.name) !== task) return;
 
       pendingThemeLoadsRef.current.delete(task.name);
-      if (task.status === "active") {
-        activeThemeLoadsRef.current = Math.max(0, activeThemeLoadsRef.current - 1);
-      } else {
+      if (task.status === "queued") {
         queuedThemeLoadsRef.current = queuedThemeLoadsRef.current.filter(
           (queuedTask) => queuedTask !== task
         );
       }
 
+      // Active tasks keep their concurrency slot until the fetch promise
+      // settles. This prevents replacements from exceeding the global cap
+      // while an aborted request is still winding down.
       task.controller.abort();
       task.resolve();
       updateLoadingMore();
@@ -107,6 +126,7 @@ export function ThemeBrowser() {
       }
 
       task.status = "active";
+      task.occupiesSlot = true;
       activeThemeLoadsRef.current += 1;
 
       void fetchTheme(task.name, { signal: task.controller.signal })
@@ -123,22 +143,45 @@ export function ThemeBrowser() {
           next.set(task.name, theme);
           loadedThemesRef.current = next;
           setLoadedThemes(next);
+          setFailedThemeNames((prev) => {
+            if (!prev.has(task.name)) return prev;
+            const failures = new Set(prev);
+            failures.delete(task.name);
+            return failures;
+          });
         })
-        .catch(() => undefined)
-        .finally(() => {
-          if (pendingThemeLoadsRef.current.get(task.name) !== task) return;
+        .catch((error: unknown) => {
+          const wasAborted =
+            task.controller.signal.aborted ||
+            (error instanceof Error && error.name === "AbortError");
+          if (
+            wasAborted ||
+            !isMountedRef.current ||
+            pendingThemeLoadsRef.current.get(task.name) !== task
+          ) {
+            return;
+          }
 
-          pendingThemeLoadsRef.current.delete(task.name);
-          activeThemeLoadsRef.current = Math.max(
-            0,
-            activeThemeLoadsRef.current - 1
-          );
-          task.resolve();
-          updateLoadingMore();
+          setFailedThemeNames((prev) => {
+            if (prev.has(task.name)) return prev;
+            const failures = new Set(prev);
+            failures.add(task.name);
+            return failures;
+          });
+        })
+        .finally(() => {
+          releaseThemeLoadSlot(task);
+
+          if (pendingThemeLoadsRef.current.get(task.name) === task) {
+            pendingThemeLoadsRef.current.delete(task.name);
+            task.resolve();
+            updateLoadingMore();
+          }
+
           drainThemeQueueRef.current();
         });
     }
-  }, [updateLoadingMore]);
+  }, [releaseThemeLoadSlot, updateLoadingMore]);
   drainThemeQueueRef.current = drainThemeQueue;
 
   // Schedule per-theme work so overlapping UI requests share one fetch. Newer
@@ -171,7 +214,9 @@ export function ThemeBrowser() {
           name,
           priority,
           order: themeLoadOrderRef.current++,
+          generation: themeLoadGenerationRef.current,
           status: "queued",
+          occupiesSlot: false,
           priorities,
           controller: new AbortController(),
           promise,
@@ -219,6 +264,7 @@ export function ThemeBrowser() {
     return () => {
       isMountedRef.current = false;
       controller.abort();
+      themeLoadGenerationRef.current += 1;
       for (const task of [...pendingThemeLoads.values()]) {
         detachThemeLoad(task);
       }
@@ -336,6 +382,11 @@ export function ThemeBrowser() {
   const handleLoadAll = async () => {
     const allNames = themeList.map((t) => t.name);
     await loadThemeBatch(allNames, "manual");
+  };
+
+  const handleRetryFailedThemes = () => {
+    const priority = ++searchPriorityRef.current;
+    void loadThemeBatch([...failedThemeNames], "manual", priority);
   };
 
   // Apply theme
@@ -457,6 +508,27 @@ export function ThemeBrowser() {
           </Badge>
         )}
       </div>
+
+      {failedThemeNames.size > 0 && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex flex-wrap items-center gap-2 text-sm text-destructive"
+        >
+          <span>
+            {failedThemeNames.size} {failedThemeNames.size === 1 ? "theme" : "themes"}{" "}
+            failed to load.
+          </span>
+          <Button
+            variant="link"
+            size="sm"
+            onClick={handleRetryFailedThemes}
+            className="h-auto p-0 text-destructive"
+          >
+            Retry failed {failedThemeNames.size === 1 ? "theme" : "themes"}
+          </Button>
+        </div>
+      )}
 
       {/* Theme grid */}
       {loading ? (

--- a/src/components/themes/ThemeCard.test.tsx
+++ b/src/components/themes/ThemeCard.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeCard } from './ThemeCard';
+import type { Theme } from '@/lib/utils/themes';
+
+const theme: Theme = {
+  name: 'Dracula',
+  raw: '',
+  colors: {
+    background: '#282a36',
+    foreground: '#f8f8f2',
+    palette: Array(16).fill(''),
+  },
+};
+
+describe('ThemeCard', () => {
+  it('applies a theme synchronously without leaving delayed work behind', () => {
+    const onApply = vi.fn();
+    render(<ThemeCard theme={theme} onApply={onApply} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Dracula theme' }));
+
+    expect(onApply).toHaveBeenCalledOnce();
+    expect(onApply).toHaveBeenCalledWith(theme);
+  });
+
+  it('exposes the applied state in the action name', () => {
+    render(<ThemeCard theme={theme} isActive onApply={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Applied Dracula theme' })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/themes/ThemeCard.tsx
+++ b/src/components/themes/ThemeCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { useState, useRef, useId } from "react";
+import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Theme, categorizeTheme } from "@/lib/utils/themes";
@@ -13,15 +13,15 @@ interface ThemeCardProps {
 }
 
 export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
-  const [isApplying, setIsApplying] = useState(false);
-  const cardRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const cardRef = useRef<HTMLElement>(null);
   const [transform, setTransform] = useState({ rotateX: 0, rotateY: 0 });
   const [isHovering, setIsHovering] = useState(false);
 
   const isDark = categorizeTheme(theme) === "dark";
   const { background, foreground, palette } = theme.colors;
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLElement>) => {
     if (!cardRef.current) return;
     const rect = cardRef.current.getBoundingClientRect();
     const centerX = rect.left + rect.width / 2;
@@ -38,11 +38,8 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
     setTransform({ rotateX: 0, rotateY: 0 });
   };
 
-  const handleApply = async () => {
-    setIsApplying(true);
-    await new Promise((r) => setTimeout(r, 300));
+  const handleApply = () => {
     onApply(theme);
-    setIsApplying(false);
   };
 
   // Get 8 main colors from palette for preview
@@ -50,8 +47,9 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
 
   return (
     <div style={{ perspective: "800px" }}>
-      <div
+      <article
         ref={cardRef}
+        aria-labelledby={titleId}
         onMouseMove={handleMouseMove}
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={handleMouseLeave}
@@ -71,6 +69,7 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
       >
         {/* Terminal Preview */}
         <div
+          aria-hidden="true"
           className="p-4"
           style={{ backgroundColor: background, color: foreground }}
         >
@@ -108,7 +107,7 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
         </div>
 
         {/* Color palette strip */}
-        <div className="flex h-2">
+        <div aria-hidden="true" className="flex h-2">
           {previewColors.length > 0
             ? previewColors.map((color, i) => (
                 <div
@@ -133,7 +132,13 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
         {/* Info and action */}
         <div className="p-3 bg-card flex items-center justify-between">
           <div>
-            <h3 className="font-medium text-sm truncate">{theme.name}</h3>
+            <h3
+              id={titleId}
+              className="font-medium text-sm truncate"
+              title={theme.name}
+            >
+              {theme.name}
+            </h3>
             <p className="text-xs text-muted-foreground">
               {isDark ? "Dark" : "Light"} theme
             </p>
@@ -143,12 +148,14 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
             size="sm"
             variant={isActive ? "secondary" : "default"}
             onClick={handleApply}
-            disabled={isApplying}
+            aria-label={
+              isActive
+                ? `Applied ${theme.name} theme`
+                : `Apply ${theme.name} theme`
+            }
             className="gap-1.5"
           >
-            {isApplying ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : isActive ? (
+            {isActive ? (
               <>
                 <Check className="h-3.5 w-3.5" />
                 Applied
@@ -158,7 +165,7 @@ export function ThemeCard({ theme, isActive, onApply }: ThemeCardProps) {
             )}
           </Button>
         </div>
-      </div>
+      </article>
     </div>
   );
 }

--- a/src/lib/utils/themes.test.ts
+++ b/src/lib/utils/themes.test.ts
@@ -239,6 +239,20 @@ describe('theme fetch hardening', () => {
       ]);
     });
 
+    it('forwards an abort signal to the theme list request', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockResolvedValue(
+        new Response('[]', { headers: { 'content-type': 'application/json' } })
+      );
+
+      await fetchThemeList({ signal: controller.signal });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('api.github.com'),
+        expect.objectContaining({ signal: controller.signal })
+      );
+    });
+
     it('accepts a valid GitHub API list larger than the individual theme-file cap', async () => {
       const entries = Array.from({ length: 3000 }, (_, index) => ({
         type: 'file',
@@ -304,6 +318,22 @@ describe('theme fetch hardening', () => {
       expect(result.colors.background).toBe('#1a1b26');
       expect(result.colors.foreground).toBe('#c0caf5');
       expect(result.raw).toBe(theme);
+    });
+
+    it('forwards an abort signal to the theme request', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockResolvedValue(
+        new Response('background = #000000', {
+          headers: { 'content-type': 'text/plain' },
+        })
+      );
+
+      await fetchTheme('Tokyo Night', { signal: controller.signal });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/Tokyo%20Night'),
+        expect.objectContaining({ signal: controller.signal })
+      );
     });
 
     it('rejects when the content-type is not text', async () => {

--- a/src/lib/utils/themes.ts
+++ b/src/lib/utils/themes.ts
@@ -149,12 +149,15 @@ export function parseThemeContent(content: string): ThemeColors {
 }
 
 // Fetch list of available themes from GitHub
-export async function fetchThemeList(): Promise<ThemeListItem[]> {
+export async function fetchThemeList(
+  options: { signal?: AbortSignal } = {}
+): Promise<ThemeListItem[]> {
   const response = await fetch(GITHUB_API_BASE, {
     headers: {
       Accept: "application/vnd.github.v3+json",
     },
     next: { revalidate: 3600 }, // Cache for 1 hour
+    signal: options.signal,
   });
 
   if (!response.ok) {
@@ -188,12 +191,16 @@ export async function fetchThemeList(): Promise<ThemeListItem[]> {
 }
 
 // Fetch a single theme by name
-export async function fetchTheme(name: string): Promise<Theme> {
+export async function fetchTheme(
+  name: string,
+  options: { signal?: AbortSignal } = {}
+): Promise<Theme> {
   const encodedName = encodeURIComponent(name);
   const url = `${RAW_CONTENT_BASE}/${encodedName}`;
 
   const response = await fetch(url, {
     next: { revalidate: 86400 }, // Cache for 24 hours
+    signal: options.signal,
   });
 
   if (!response.ok) {
@@ -214,7 +221,9 @@ export async function fetchTheme(name: string): Promise<Theme> {
 
 // Fetch multiple themes in parallel
 export async function fetchThemes(names: string[]): Promise<Theme[]> {
-  const results = await Promise.allSettled(names.map(fetchTheme));
+  const results = await Promise.allSettled(
+    names.map((name) => fetchTheme(name))
+  );
   
   return results
     .filter((result): result is PromiseFulfilledResult<Theme> => 


### PR DESCRIPTION
## Summary

- bound theme downloads to six concurrent requests, deduplicate overlapping work, prioritize current searches, and cancel stale work without oversubscribing the queue
- surface individual theme download failures with retry controls
- prevent stale Ghostty WASM initialization from attaching or leaking terminal resources after close, reopen, or superseding config changes
- improve preview and theme-browser accessibility, including live status announcements and 320px mobile reflow
- add focused unit and Playwright coverage for concurrency, cancellation, lifecycle races, responsive behavior, and WCAG A/AA checks

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test -- --run` — 25 files, 329 tests passed
- `bun run build`
- `bun run schema:check` — 202 local option IDs matched 202 upstream Ghostty option IDs
- `CI=1 bun run test:e2e` — 11 tests passed
- `git diff --check main..HEAD`
