### PR TITLE
feat(import): review unknown options and reject unsafe keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Generated config headers now identify Spectre's Ghostty schema target and warn when imported options fall outside it.
 - Config file imports now open a review step before atomically replacing the current editor state.
 - Import review now supports explicit partial replacement when known values are invalid.
+- Unknown imported options are retained as visibly unverified strings, while unsafe or non-Ghostty-style option names are rejected before apply.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -164,10 +164,10 @@ test("a user can explicitly import valid settings from a partially invalid file"
   });
 
   await expect(
-    page.getByText(
-      "Error — Line 2 · mouse-hide-while-typing: Use 1, 0, t, T, f, F, true, or false."
-    )
-  ).toBeVisible();
+    page.getByRole("list", { name: "Import issues" })
+  ).toContainText(
+    "Error — Line 2 · mouse-hide-while-typing: Use 1, 0, t, T, f, F, true, or false."
+  );
   await page
     .getByRole("button", { name: "Replace with 2 settings and skip 1 line" })
     .click();
@@ -182,6 +182,59 @@ test("a user can explicitly import valid settings from a partially invalid file"
   await expect(page.locator("pre")).toContainText("font-size = 16");
   await expect(page.locator("pre")).toContainText("cursor-style = bar");
   await expect(page.locator("pre")).not.toContainText("mouse-hide-while-typing");
+});
+
+test("a user can retain unverified options while unsafe names are rejected", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import Config" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "text/plain",
+    buffer: Buffer.from(
+      'font-szie = 15\nfuture-option = first\nfuture-option = "second = value"\n__proto__ = polluted\nconstructor = polluted\n'
+    ),
+  });
+
+  const typoInstruction = page.getByRole("link", {
+    name: "font-szie",
+    exact: true,
+  });
+  await expect(typoInstruction.locator("..")).toContainText("font-szie = 15");
+  const futureInstruction = page.getByRole("link", {
+    name: "future-option",
+    exact: true,
+  });
+  await expect(futureInstruction).toHaveCount(1);
+  await expect(futureInstruction.locator("..")).toContainText(
+    "future-option = second = value"
+  );
+  await expect(page.getByText("Unverified", { exact: true })).toHaveCount(2);
+  await expect(
+    page.getByRole("list", { name: "Import issues" })
+  ).toContainText(
+    "Error — Line 4 · __proto__: This option name is reserved and cannot be imported safely."
+  );
+
+  await page
+    .getByRole("button", { name: "Replace with 2 settings and skip 2 lines" })
+    .click();
+  await expect(page.getByText("2 modified", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "View Config" }).click();
+  const output = page.locator("pre");
+  await expect(output).toContainText(
+    "Warning: contains 2 options outside this schema target"
+  );
+  await expect(output).toContainText("font-szie = 15");
+  await expect(output).toContainText('future-option = "second = value"');
+  await expect(output).not.toContainText("future-option = first");
+  await expect(output).not.toContainText("__proto__");
+  await expect(output).not.toContainText("constructor =");
 });
 
 test("a user can navigate and inspect configuration on a mobile screen", async ({

--- a/src/components/editor/ImportReviewDialog.test.tsx
+++ b/src/components/editor/ImportReviewDialog.test.tsx
@@ -3,6 +3,14 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ImportReviewDialog } from './ImportReviewDialog';
 import { analyzeGhosttyConfig } from '@/lib/utils/config-import-analysis';
 
+function expectImportedInstruction(key: string, text: string) {
+  expect(screen.getByRole('link', { name: key }).closest('li')).toHaveTextContent(text);
+}
+
+function expectImportIssue(text: string | RegExp) {
+  expect(screen.getByRole('list', { name: 'Import issues' })).toHaveTextContent(text);
+}
+
 describe('ImportReviewDialog', () => {
   it('shows valid imported instructions before confirmation', async () => {
     const analysis = analyzeGhosttyConfig(`
@@ -30,15 +38,108 @@ cursor-style = bar
     expect(
       screen.getByText(/2 current settings will be replaced\./)
     ).toBeInTheDocument();
-    expect(screen.getByText('font-size = 16')).toBeInTheDocument();
-    expect(screen.getByText('font-family = JetBrains Mono')).toBeInTheDocument();
-    expect(screen.getByText('cursor-style = bar')).toBeInTheDocument();
+    expectImportedInstruction('font-size', 'font-size = 16');
+    expectImportedInstruction('font-family', 'font-family = JetBrains Mono');
+    expectImportedInstruction('cursor-style', 'cursor-style = bar');
 
     const cancel = screen.getByRole('button', { name: 'Cancel' });
     await waitFor(() => expect(cancel).toHaveFocus());
 
     fireEvent.click(screen.getByRole('button', { name: 'Replace with 3 settings' }));
     expect(onConfirm).toHaveBeenCalledWith(analysis.candidateConfig);
+  });
+
+  it('labels unknown instructions as unverified and links to published sources', () => {
+    const analysis = analyzeGhosttyConfig(`
+font-size = 16
+future-option = "raw = value"
+mouse-hide-while-typing = maybe
+`);
+
+    render(
+      <ImportReviewDialog
+        open
+        fileName="config"
+        fileSize={48}
+        currentSettingCount={0}
+        analysis={analysis}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const knownSource = screen.getByRole('link', { name: 'font-size' });
+    expect(knownSource).toHaveAttribute(
+      'href',
+      'https://ghostty.org/docs/config/reference#font-size'
+    );
+    expect(knownSource).toHaveAttribute('target', '_blank');
+    expect(knownSource).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(knownSource).toHaveAccessibleDescription('Opens in a new tab.');
+
+    const unknownSource = screen.getByRole('link', { name: 'future-option' });
+    expect(unknownSource).toHaveAttribute(
+      'href',
+      'https://ghostty.org/docs/config/reference'
+    );
+    expect(unknownSource).toHaveAttribute('target', '_blank');
+    expect(unknownSource).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByText('Unverified')).toBeInTheDocument();
+
+    const knownIssueSource = screen.getByRole('link', {
+      name: 'Ghostty reference for mouse-hide-while-typing',
+    });
+    expect(knownIssueSource).toHaveAttribute(
+      'href',
+      'https://ghostty.org/docs/config/reference#mouse-hide-while-typing'
+    );
+    expect(knownIssueSource).toHaveAttribute('target', '_blank');
+    expect(knownIssueSource).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const unknownIssueSource = screen.getByRole('link', {
+      name: 'Ghostty reference for future-option',
+    });
+    expect(unknownIssueSource).toHaveAttribute(
+      'href',
+      'https://ghostty.org/docs/config/reference'
+    );
+    expect(unknownIssueSource).toHaveAttribute('target', '_blank');
+    expect(unknownIssueSource).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const compatibilityPolicy = screen.getByRole('link', {
+      name: 'Spectre compatibility policy',
+    });
+    expect(compatibilityPolicy).toHaveAttribute(
+      'href',
+      'https://github.com/imrajyavardhan12/spectre-ghostty-config/blob/main/COMPATIBILITY.md'
+    );
+    expect(compatibilityPolicy).toHaveAttribute('target', '_blank');
+    expect(compatibilityPolicy).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('shows related source lines for repeated unknown options', () => {
+    const analysis = analyzeGhosttyConfig(`
+future-option = first
+future-option = second
+future-option = third
+`);
+
+    render(
+      <ImportReviewDialog
+        open
+        fileName="config"
+        fileSize={72}
+        currentSettingCount={0}
+        analysis={analysis}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('future-option = first')).not.toBeInTheDocument();
+    expect(screen.queryByText('future-option = second')).not.toBeInTheDocument();
+    expectImportedInstruction('future-option', 'future-option = third');
+    expectImportIssue(/Line 4.*Related lines: 2, 3\./);
   });
 
   it('shows invalid known values and explicit partial-import action copy', () => {
@@ -60,8 +161,8 @@ mouse-hide-while-typing = maybe
       />
     );
 
-    expect(screen.getByText('font-size = 16')).toBeInTheDocument();
-    expect(screen.getByText(/Line 3.*Use 1, 0, t, T, f, F, true, or false\./)).toBeInTheDocument();
+    expectImportedInstruction('font-size', 'font-size = 16');
+    expectImportIssue(/Line 3.*Use 1, 0, t, T, f, F, true, or false\./);
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -86,11 +187,9 @@ mouse-hide-while-typing = maybe
       />
     );
 
-    expect(
-      screen.getByText(
-        'Warning — Line 1 · cursor-opacity: Ghostty will clamp values above 1 down to 1.'
-      )
-    ).toBeInTheDocument();
+    expectImportIssue(
+      'Warning — Line 1 · cursor-opacity: Ghostty will clamp values above 1 down to 1.'
+    );
     expect(
       screen.getByRole('button', { name: 'Replace with 1 setting' })
     ).toBeEnabled();
@@ -115,7 +214,10 @@ mouse-hide-while-typing = maybe
     expect(
       screen.getByRole('button', { name: 'Replace current config with defaults' })
     ).toBeEnabled();
-    expect(screen.getByText('cursor-style = (reset to default)')).toBeInTheDocument();
+    expectImportedInstruction(
+      'cursor-style',
+      'cursor-style = (reset to default)'
+    );
   });
 
   it('disables replacement when no meaningful instruction exists', () => {

--- a/src/components/editor/ImportReviewDialog.tsx
+++ b/src/components/editor/ImportReviewDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useId, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,7 +11,15 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { ConfigValues } from "@/lib/schema/types";
-import type { ImportAnalysis, ImportInstruction } from "@/lib/utils/config-import-analysis";
+import type {
+  ImportAnalysis,
+  ImportDiagnostic,
+  ImportInstruction,
+} from "@/lib/utils/config-import-analysis";
+
+const GHOSTTY_CONFIG_REFERENCE_URL = "https://ghostty.org/docs/config/reference";
+const SPECTRE_COMPATIBILITY_POLICY_URL =
+  "https://github.com/imrajyavardhan12/spectre-ghostty-config/blob/main/COMPATIBILITY.md";
 
 interface ImportReviewDialogProps {
   open: boolean;
@@ -28,12 +36,34 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-function formatInstruction(instruction: ImportInstruction): string {
+function formatInstructionValue(instruction: ImportInstruction): string {
   if (instruction.disposition === "reset") {
-    return `${instruction.key} = (reset to default)`;
+    return "(reset to default)";
   }
 
-  return `${instruction.key} = ${String(instruction.normalizedValue ?? "")}`;
+  return String(instruction.normalizedValue ?? "");
+}
+
+function formatDiagnosticSeverity(diagnostic: ImportDiagnostic): string {
+  if (diagnostic.severity === "error") return "Error";
+  if (diagnostic.severity === "warning") return "Warning";
+  return "Info";
+}
+
+function formatRelatedLines(diagnostic: ImportDiagnostic): string {
+  if (!diagnostic.relatedLineNumbers?.length) return "";
+
+  const label = diagnostic.relatedLineNumbers.length === 1
+    ? "Related line"
+    : "Related lines";
+  return ` ${label}: ${diagnostic.relatedLineNumbers.join(", ")}.`;
+}
+
+function getDiagnosticSourceUrl(diagnostic: ImportDiagnostic): string {
+  return diagnostic.code === "unknown-option" ||
+    diagnostic.code === "unsafe-option-name"
+    ? GHOSTTY_CONFIG_REFERENCE_URL
+    : `${GHOSTTY_CONFIG_REFERENCE_URL}#${diagnostic.key}`;
 }
 
 export function ImportReviewDialog({
@@ -46,10 +76,14 @@ export function ImportReviewDialog({
   onConfirm,
 }: ImportReviewDialogProps) {
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const externalLinkDescriptionId = useId();
   const effectiveInstructions = analysis.instructions.filter(
     (instruction) =>
       instruction.disposition === "retained" ||
       instruction.disposition === "reset"
+  );
+  const hasUnknownInstructions = effectiveInstructions.some(
+    (instruction) => !instruction.known
   );
   const resultingCount = analysis.summary.resultingSettingCount;
   const skippedCount = analysis.summary.skippedLineCount;
@@ -96,13 +130,34 @@ export function ImportReviewDialog({
         <div className="min-h-0 space-y-2 overflow-y-auto rounded-md border p-3">
           <h3 className="text-sm font-medium">Imported instructions</h3>
           {effectiveInstructions.length > 0 ? (
-            <ol className="space-y-1 font-mono text-xs">
+            <ol
+              className="space-y-1 font-mono text-xs"
+              aria-label="Imported instructions"
+            >
               {effectiveInstructions.map((instruction) => (
                 <li key={`${instruction.lineNumber}-${instruction.key}`} className="break-words">
                   <span className="mr-2 text-muted-foreground">
                     Line {instruction.lineNumber}
                   </span>
-                  {formatInstruction(instruction)}
+                  <a
+                    href={
+                      instruction.known
+                        ? `${GHOSTTY_CONFIG_REFERENCE_URL}#${instruction.key}`
+                        : GHOSTTY_CONFIG_REFERENCE_URL
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-describedby={externalLinkDescriptionId}
+                    className="underline decoration-muted-foreground underline-offset-2 hover:text-foreground"
+                  >
+                    {instruction.key}
+                  </a>
+                  {` = ${formatInstructionValue(instruction)}`}
+                  {!instruction.known && (
+                    <span className="ml-2 inline-flex rounded border px-1.5 py-0.5 font-sans text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                      Unverified
+                    </span>
+                  )}
                 </li>
               ))}
             </ol>
@@ -110,10 +165,27 @@ export function ImportReviewDialog({
             <p className="text-sm text-muted-foreground">No usable instructions found.</p>
           )}
 
+          {hasUnknownInstructions && (
+            <p className="text-xs text-muted-foreground">
+              Unverified options are retained as strings but are outside Spectre&apos;s schema
+              target. Review the{" "}
+              <a
+                href={SPECTRE_COMPATIBILITY_POLICY_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-describedby={externalLinkDescriptionId}
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Spectre compatibility policy
+              </a>
+              .
+            </p>
+          )}
+
           {analysis.diagnostics.length > 0 && (
             <div className="space-y-2 border-t pt-3">
               <h3 className="text-sm font-medium">Import issues</h3>
-              <ul className="space-y-1 text-xs">
+              <ul className="space-y-1 text-xs" aria-label="Import issues">
                 {analysis.diagnostics.map((diagnostic) => (
                   <li
                     key={`${diagnostic.lineNumber}-${diagnostic.code}`}
@@ -123,13 +195,33 @@ export function ImportReviewDialog({
                         : "break-words text-amber-600 dark:text-amber-400"
                     }
                   >
-                    {`${diagnostic.severity === "error" ? "Error" : diagnostic.severity === "warning" ? "Warning" : "Info"} — Line ${diagnostic.lineNumber}${diagnostic.key ? ` · ${diagnostic.key}` : ""}: ${diagnostic.message}`}
+                    {`${formatDiagnosticSeverity(diagnostic)} — Line ${diagnostic.lineNumber}`}
+                    {diagnostic.key && (
+                      <>
+                        {" · "}
+                        <a
+                          href={getDiagnosticSourceUrl(diagnostic)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`Ghostty reference for ${diagnostic.key}`}
+                          aria-describedby={externalLinkDescriptionId}
+                          className="underline underline-offset-2"
+                        >
+                          {diagnostic.key}
+                        </a>
+                      </>
+                    )}
+                    {`: ${diagnostic.message}${formatRelatedLines(diagnostic)}`}
                   </li>
                 ))}
               </ul>
             </div>
           )}
         </div>
+
+        <span id={externalLinkDescriptionId} className="sr-only">
+          Opens in a new tab.
+        </span>
 
         <DialogFooter>
           <Button

--- a/src/data/ghostty-options.test.ts
+++ b/src/data/ghostty-options.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { allOptions, getOptionById, getOptionsByCategory } from '@/data/ghostty-options';
 import { categories } from '@/data/categories';
 import type { Category } from '@/lib/schema/types';
+import { isSafeConfigKey } from '@/lib/security/config-key-safety';
 
 describe('ghostty-options', () => {
   describe('allOptions', () => {
@@ -43,9 +44,9 @@ describe('ghostty-options', () => {
       expect(uniqueIds.size).toBe(ids.length);
     });
 
-    it('should have string id format (kebab-case)', () => {
+    it('should have safe Ghostty-style option ids', () => {
       for (const option of allOptions) {
-        expect(option.id).toMatch(/^[a-z][a-z0-9-]*$/);
+        expect(isSafeConfigKey(option.id), option.id).toBe(true);
       }
     });
   });

--- a/src/lib/security/config-key-safety.test.ts
+++ b/src/lib/security/config-key-safety.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeConfigKey,
+  isUnsafeConfigKey,
+} from "@/lib/security/config-key-safety";
+
+describe("config key safety", () => {
+  it("accepts lowercase Ghostty-style option names", () => {
+    for (const key of ["theme", "future-option", "future-option-2"]) {
+      expect(isSafeConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("rejects names outside the lowercase Ghostty option grammar", () => {
+    for (const key of [
+      "",
+      "Future-option",
+      "future_option",
+      "future option",
+      "future--option",
+      "-future-option",
+      "future-option-",
+    ]) {
+      expect(isSafeConfigKey(key), key).toBe(false);
+    }
+  });
+
+  it("rejects prototype-chain and reserved property names", () => {
+    for (const key of [
+      "__proto__",
+      "constructor",
+      "prototype",
+      "toString",
+      "hasOwnProperty",
+    ]) {
+      expect(isUnsafeConfigKey(key), key).toBe(true);
+      expect(isSafeConfigKey(key), key).toBe(false);
+    }
+  });
+});

--- a/src/lib/security/config-key-safety.ts
+++ b/src/lib/security/config-key-safety.ts
@@ -1,0 +1,28 @@
+// Ghostty 1.3.1 public Config.zig fields and reference anchors use lowercase
+// ASCII segments separated by single hyphens. Future keys stay within that
+// published shape before Spectre retains them as unverified values.
+const GHOSTTY_OPTION_NAME_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+const UNSAFE_CONFIG_KEYS = new Set([
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "__proto__",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "prototype",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+]);
+
+export function isUnsafeConfigKey(key: string): boolean {
+  return UNSAFE_CONFIG_KEYS.has(key);
+}
+
+export function isSafeConfigKey(key: string): boolean {
+  return GHOSTTY_OPTION_NAME_PATTERN.test(key) && !isUnsafeConfigKey(key);
+}

--- a/src/lib/store/config-store.test.ts
+++ b/src/lib/store/config-store.test.ts
@@ -174,6 +174,40 @@ describe('config-store', () => {
   });
 
   describe('applyImportedCandidate', () => {
+    it('stores reviewed candidates in a null-prototype dictionary and drops unsafe keys', () => {
+      const candidate = JSON.parse(
+        '{"__proto__":{"polluted":true},"constructor":"bad","prototype":"bad","future-option":"safe"}'
+      );
+
+      act(() => {
+        useConfigStore.getState().applyImportedCandidate(candidate);
+      });
+
+      const stored = getStoreState().config;
+      expect(stored).toEqual({ 'future-option': 'safe' });
+      expect(Object.getPrototypeOf(stored)).toBeNull();
+      expect(Object.hasOwn(stored, '__proto__')).toBe(false);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('keeps imported config dictionaries prototype-free after resets', () => {
+      act(() => {
+        useConfigStore.getState().applyImportedCandidate({
+          'font-size': 16,
+          'future-option': 'safe',
+        });
+        useConfigStore.getState().resetValue('font-size');
+      });
+
+      expect(getStoreState().config).toEqual({ 'future-option': 'safe' });
+      expect(Object.getPrototypeOf(getStoreState().config)).toBeNull();
+
+      act(() => {
+        useConfigStore.getState().resetAll();
+      });
+      expect(Object.getPrototypeOf(getStoreState().config)).toBeNull();
+    });
+
     it('atomically replaces config, clears theme metadata, and clones arrays', () => {
       const candidate = {
         'font-size': 16,
@@ -192,6 +226,26 @@ describe('config-store', () => {
         'font-family': ['JetBrains Mono', 'Symbols Nerd Font'],
       });
       expect(state.appliedTheme).toBeNull();
+    });
+  });
+
+  describe('persistence safety', () => {
+    it('normalizes persisted config before hydrating the store', async () => {
+      localStorage.setItem(
+        'spectre-config',
+        '{"state":{"config":{"__proto__":{"polluted":true},"constructor":"bad","future-option":"safe"},"appliedTheme":"Dracula"},"version":0}'
+      );
+
+      await act(async () => {
+        await useConfigStore.persist.rehydrate();
+      });
+
+      const state = getStoreState();
+      expect(state.config).toEqual({ 'future-option': 'safe' });
+      expect(Object.getPrototypeOf(state.config)).toBeNull();
+      expect(Object.hasOwn(state.config, '__proto__')).toBe(false);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(state.appliedTheme).toBe('Dracula');
     });
   });
 

--- a/src/lib/store/config-store.ts
+++ b/src/lib/store/config-store.ts
@@ -4,7 +4,10 @@ import { useState, useEffect } from "react";
 import type { ConfigValues } from "@/lib/schema/types";
 import { exportGhosttyConfig } from "@/lib/utils/config-export";
 import { getDefaultValue } from "@/lib/utils/config-options";
-import { normalizeConfigValues } from "@/lib/utils/config-normalization";
+import {
+  createConfigValues,
+  normalizeConfigValues,
+} from "@/lib/utils/config-normalization";
 import { isThemeConfigKey } from "@/lib/utils/theme-config";
 
 export type { ConfigValues };
@@ -35,7 +38,7 @@ interface ConfigStore {
 export const useConfigStore = create<ConfigStore>()(
   persist(
     (set, get) => ({
-      config: {},
+      config: createConfigValues(),
       appliedTheme: null,
 
       setValue: (key: string, value: unknown) => {
@@ -54,7 +57,7 @@ export const useConfigStore = create<ConfigStore>()(
 
       resetValue: (key: string) => {
         set((state) => {
-          const newConfig = { ...state.config };
+          const newConfig = normalizeConfigValues(state.config);
           delete newConfig[key];
           return {
             config: newConfig,
@@ -64,7 +67,7 @@ export const useConfigStore = create<ConfigStore>()(
       },
 
       resetAll: () => {
-        set({ config: {}, appliedTheme: null });
+        set({ config: createConfigValues(), appliedTheme: null });
       },
       
       setAppliedTheme: (themeName: string | null) => {
@@ -93,13 +96,7 @@ export const useConfigStore = create<ConfigStore>()(
       },
 
       applyImportedCandidate: (candidate: ConfigValues) => {
-        const cloned = Object.fromEntries(
-          Object.entries(candidate).map(([key, value]) => [
-            key,
-            Array.isArray(value) ? [...value] : value,
-          ])
-        );
-        set({ config: normalizeConfigValues(cloned), appliedTheme: null });
+        set({ config: normalizeConfigValues(candidate), appliedTheme: null });
       },
 
       exportConfig: () => {
@@ -110,6 +107,21 @@ export const useConfigStore = create<ConfigStore>()(
     {
       name: "spectre-config",
       partialize: (state) => ({ config: state.config, appliedTheme: state.appliedTheme }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<
+          Pick<ConfigStore, "config" | "appliedTheme">
+        >;
+        const config = persisted.config &&
+          typeof persisted.config === "object" &&
+          !Array.isArray(persisted.config)
+          ? normalizeConfigValues(persisted.config)
+          : createConfigValues();
+        const appliedTheme = typeof persisted.appliedTheme === "string"
+          ? persisted.appliedTheme
+          : null;
+
+        return { ...currentState, config, appliedTheme };
+      },
       skipHydration: true,
     }
   )

--- a/src/lib/utils/config-export.test.ts
+++ b/src/lib/utils/config-export.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { exportGhosttyConfig } from '@/lib/utils/config-export';
 import { GHOSTTY_COMPATIBILITY_VERSION } from '@/lib/compatibility';
 import { SPECTRE_VERSION } from '@/lib/version';
+import { analyzeGhosttyConfig } from '@/lib/utils/config-import-analysis';
 
 describe('exportGhosttyConfig', () => {
   it('renders Ghostty config output without depending on the Zustand store', () => {
@@ -32,5 +33,36 @@ describe('exportGhosttyConfig', () => {
     expect(output).toContain('gtk-custom-css = "?required.css"');
     expect(output).toContain('gtk-custom-css = ?optional.css');
     expect(output).toContain('unknown-option = "raw = value"');
+  });
+
+  it('round-trips normalized unverified string edge cases', () => {
+    const analysis = analyzeGhosttyConfig(`
+future-embedded = "say "hello" = now"
+future-empty = ""
+future-comment = #not-an-inline-comment
+future-leading-space = "  padded value  "
+future-unmatched-double = "literal
+future-unmatched-single = '
+`);
+
+    const exported = exportGhosttyConfig(analysis.normalizedConfig);
+    const reanalyzed = analyzeGhosttyConfig(exported);
+
+    expect(reanalyzed.normalizedConfig).toEqual(analysis.normalizedConfig);
+  });
+
+  it('exports only the retained value for repeated unverified options', () => {
+    const analysis = analyzeGhosttyConfig(`
+future-option = first
+future-option = "second = value"
+`);
+
+    const output = exportGhosttyConfig(analysis.normalizedConfig);
+
+    expect(output).toContain(
+      '# Warning: contains 1 option outside this schema target; validate with your Ghostty build.'
+    );
+    expect(output).toContain('future-option = "second = value"');
+    expect(output).not.toContain('future-option = first');
   });
 });

--- a/src/lib/utils/config-import-analysis.test.ts
+++ b/src/lib/utils/config-import-analysis.test.ts
@@ -52,6 +52,135 @@ cursor-style = bar
     expect(analysis.hasMeaningfulInstruction).toBe(true);
   });
 
+  it('normalizes unknown option values as unverified safe candidate data', () => {
+    const analysis = analyzeGhosttyConfig(`
+future-command = left=right
+future-double = "double = value"
+future-single = 'single = value'
+future-empty =
+future-quoted-empty = ""
+future-unmatched = "literal
+future-unmatched-single = '
+`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'future-command': 'left=right',
+      'future-double': 'double = value',
+      'future-single': 'single = value',
+      'future-empty': '',
+      'future-quoted-empty': '',
+      'future-unmatched': '"literal',
+      'future-unmatched-single': "'",
+    });
+    expect(Object.getPrototypeOf(analysis.candidateConfig)).toBeNull();
+    expect(Object.getPrototypeOf(analysis.normalizedConfig)).toBeNull();
+    expect(analysis.diagnostics).toHaveLength(7);
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unknown-option',
+          severity: 'warning',
+          lineNumber: 2,
+          key: 'future-command',
+        }),
+      ])
+    );
+    expect(analysis.instructions.every((instruction) => !instruction.known)).toBe(true);
+  });
+
+  it('retains the last repeated unknown value and reports every related line', () => {
+    const analysis = analyzeGhosttyConfig(`
+future-option = first
+future-option = "second = value"
+future-option =
+`);
+
+    expect(analysis.candidateConfig['future-option']).toBe('');
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['overridden', 'overridden', 'retained']);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 3,
+      effectiveInstructionCount: 1,
+      skippedLineCount: 0,
+      resultingSettingCount: 1,
+    });
+
+    const unknownDiagnostics = analysis.diagnostics.filter(
+      (diagnostic) => diagnostic.code === 'unknown-option'
+    );
+    expect(unknownDiagnostics).toHaveLength(1);
+    expect(unknownDiagnostics[0]).toMatchObject({
+      lineNumber: 4,
+      relatedLineNumbers: [2, 3],
+    });
+  });
+
+  it('handles many repeated unknown options with one effective value', () => {
+    const source = Array.from(
+      { length: 10_000 },
+      (_, index) => `future-option = value-${index}`
+    ).join('\n');
+
+    const analysis = analyzeGhosttyConfig(source);
+
+    expect(analysis.candidateConfig['future-option']).toBe('value-9999');
+    expect(analysis.instructions).toHaveLength(10_000);
+    expect(analysis.instructions[0].disposition).toBe('overridden');
+    expect(analysis.instructions[9_999].disposition).toBe('retained');
+    expect(analysis.diagnostics).toHaveLength(1);
+    expect(analysis.diagnostics[0].relatedLineNumbers).toHaveLength(9_999);
+    expect(analysis.diagnostics[0].relatedLineNumbers?.[0]).toBe(1);
+    expect(analysis.diagnostics[0].relatedLineNumbers?.[9_998]).toBe(9_999);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 10_000,
+      effectiveInstructionCount: 1,
+      skippedLineCount: 0,
+      resultingSettingCount: 1,
+    });
+  });
+
+  it('rejects unsafe or non-Ghostty unknown option names', () => {
+    const analysis = analyzeGhosttyConfig(`
+__proto__ = polluted
+constructor = polluted
+prototype = polluted
+toString = polluted
+future_option = invalid
+Future-option = invalid
+future--option = invalid
+-future = invalid
+future- = invalid
+ = missing
+future-option-2 = retained
+`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'future-option-2': 'retained',
+    });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'unsafe-option-name'
+      )
+    ).toHaveLength(9);
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'empty-key',
+          severity: 'error',
+          lineNumber: 11,
+        }),
+      ])
+    );
+    expect(
+      analysis.instructions.filter(
+        (instruction) => instruction.disposition === 'invalid'
+      )
+    ).toHaveLength(10);
+    expect(analysis.summary.skippedLineCount).toBe(10);
+  });
+
   it('keeps explicit reset/default intent meaningful when the stored diff is empty', () => {
     const analysis = analyzeGhosttyConfig(`
 font-size = 13

--- a/src/lib/utils/config-import-analysis.ts
+++ b/src/lib/utils/config-import-analysis.ts
@@ -1,6 +1,13 @@
 import type { ConfigValues, NumberOption } from "@/lib/schema/types";
+import {
+  isSafeConfigKey,
+  isUnsafeConfigKey,
+} from "@/lib/security/config-key-safety";
 import { getConfigOption, isPathOption } from "@/lib/utils/config-options";
-import { normalizeConfigValues } from "@/lib/utils/config-normalization";
+import {
+  createConfigValues,
+  normalizeConfigValues,
+} from "@/lib/utils/config-normalization";
 import { validateConfigValue } from "@/lib/utils/config-validation";
 
 export type ImportInstructionDisposition =
@@ -26,6 +33,9 @@ export type ImportDiagnosticCode =
   | "unsupported-number-form"
   | "unsupported-number-range"
   | "number-out-of-range"
+  | "empty-key"
+  | "unknown-option"
+  | "unsafe-option-name"
   | "invalid-enum"
   | "invalid-color"
   | "invalid-duration";
@@ -37,6 +47,11 @@ export interface ImportDiagnostic {
   key?: string;
   message: string;
   relatedLineNumbers?: number[];
+}
+
+interface UnknownOptionOccurrences {
+  retainedInstructionIndex: number;
+  overriddenLineNumbers: number[];
 }
 
 export interface ImportAnalysis {
@@ -63,8 +78,9 @@ function stripDoubleQuotes(value: string): string {
 
 function stripMatchingQuotes(value: string): string {
   if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
   ) {
     return value.slice(1, -1);
   }
@@ -212,21 +228,23 @@ function parseNumber(option: NumberOption, value: string): NumberParseResult {
 function invalidInstruction(
   lineNumber: number,
   key: string,
-  rawValue: string
+  rawValue: string,
+  known = true
 ): ImportInstruction {
   return {
     lineNumber,
     key,
     rawValue,
     disposition: "invalid",
-    known: true,
+    known,
   };
 }
 
 export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
-  const candidateConfig: ConfigValues = {};
+  const candidateConfig = createConfigValues();
   const instructions: ImportInstruction[] = [];
   const diagnostics: ImportDiagnostic[] = [];
+  const unknownOptions = new Map<string, UnknownOptionOccurrences>();
   const lines = configString.split("\n");
 
   lines.forEach((line, index) => {
@@ -250,14 +268,49 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
 
     const key = trimmed.slice(0, equalsIndex).trim();
     const rawValue = trimmed.slice(equalsIndex + 1).trim();
+
+    if (key === "") {
+      instructions.push(invalidInstruction(lineNumber, key, rawValue, false));
+      diagnostics.push({
+        code: "empty-key",
+        severity: "error",
+        lineNumber,
+        message: "Enter an option name before =.",
+      });
+      return;
+    }
+
     const option = getConfigOption(key);
     const parsedPathValue = option && isPathOption(key)
       ? parsePathValue(rawValue)
       : null;
 
+    if (!option && !isSafeConfigKey(key)) {
+      instructions.push(invalidInstruction(lineNumber, key, rawValue, false));
+      diagnostics.push({
+        code: "unsafe-option-name",
+        severity: "error",
+        lineNumber,
+        key,
+        message: isUnsafeConfigKey(key)
+          ? "This option name is reserved and cannot be imported safely."
+          : "Use a lowercase Ghostty option name containing letters, numbers, and single hyphens.",
+      });
+      return;
+    }
+
     if (!option) {
       const value = stripMatchingQuotes(rawValue);
       candidateConfig[key] = value;
+
+      const previous = unknownOptions.get(key);
+      if (previous) {
+        const overridden = instructions[previous.retainedInstructionIndex];
+        overridden.disposition = "overridden";
+        previous.overriddenLineNumbers.push(overridden.lineNumber);
+      }
+
+      const retainedInstructionIndex = instructions.length;
       instructions.push({
         lineNumber,
         key,
@@ -266,6 +319,16 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
         disposition: "retained",
         known: false,
       });
+
+      if (previous) {
+        previous.retainedInstructionIndex = retainedInstructionIndex;
+      } else {
+        unknownOptions.set(key, {
+          retainedInstructionIndex,
+          overriddenLineNumbers: [],
+        });
+      }
+
       return;
     }
 
@@ -412,13 +475,32 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
     });
   });
 
+  for (const [key, occurrence] of unknownOptions) {
+    diagnostics.push({
+      code: "unknown-option",
+      severity: "warning",
+      lineNumber: instructions[occurrence.retainedInstructionIndex].lineNumber,
+      key,
+      message: occurrence.overriddenLineNumbers.length > 0
+        ? "Spectre does not recognize this option. Its last occurrence will be retained as an unverified string."
+        : "Spectre does not recognize this option. It will be retained as an unverified string.",
+      relatedLineNumbers: occurrence.overriddenLineNumbers,
+    });
+  }
+  diagnostics.sort((a, b) => a.lineNumber - b.lineNumber);
+
   const acceptedInstructionCount = instructions.filter(
+    (instruction) =>
+      instruction.disposition === "retained" ||
+      instruction.disposition === "overridden" ||
+      instruction.disposition === "reset"
+  ).length;
+  // Known scalar override classification is added by the duplicate/order slice (#69).
+  const effectiveInstructionCount = instructions.filter(
     (instruction) =>
       instruction.disposition === "retained" ||
       instruction.disposition === "reset"
   ).length;
-  // Scalar override classification is added by the duplicate/order slice (#69).
-  const effectiveInstructionCount = acceptedInstructionCount;
   const instructionLineNumbers = new Set(
     instructions.map((instruction) => instruction.lineNumber)
   );

--- a/src/lib/utils/config-normalization.ts
+++ b/src/lib/utils/config-normalization.ts
@@ -1,13 +1,18 @@
 import type { ConfigValues } from "@/lib/schema/types";
+import { isSafeConfigKey } from "@/lib/security/config-key-safety";
 import { getDefaultValue, isRepeatableOption } from "@/lib/utils/config-options";
 import { normalizePaletteEntries } from "@/lib/utils/palette";
+
+export function createConfigValues(): ConfigValues {
+  return Object.create(null) as ConfigValues;
+}
 
 function normalizeValue(key: string, value: unknown): unknown {
   if (key === "palette" && Array.isArray(value)) {
     return normalizePaletteEntries(value as string[]);
   }
 
-  return value;
+  return Array.isArray(value) ? [...value] : value;
 }
 
 function valuesEqual(a: unknown, b: unknown): boolean {
@@ -37,9 +42,11 @@ function shouldStoreValue(key: string, value: unknown): boolean {
 }
 
 export function normalizeConfigValues(config: ConfigValues): ConfigValues {
-  const normalized: ConfigValues = {};
+  const normalized = createConfigValues();
 
   for (const [key, value] of Object.entries(config)) {
+    if (!isSafeConfigKey(key)) continue;
+
     const normalizedValue = normalizeValue(key, value);
 
     if (shouldStoreValue(key, normalizedValue)) {


### PR DESCRIPTION
## Summary

- retain forward-compatible unknown Ghostty options as visibly **Unverified** strings while preserving embedded `=` and documented quote/empty-value behavior
- keep only the final repeated unknown value, expose related source lines, and link review items to published Ghostty and Spectre compatibility sources
- reject unsafe, reserved, and non-Ghostty-style option names before apply
- keep analyzer, store, reset, and hydrated persistence dictionaries prototype-free and sanitize reviewed candidates at the store boundary
- preserve retained unknown values through export with the existing schema-target warning

## Related issue

Closes #68

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring or maintenance
- [ ] Ghostty compatibility update

## Ghostty source of truth

- [Ghostty configuration reference](https://ghostty.org/docs/config/reference)
- [Ghostty 1.3.1 pinned `Config.zig`](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/config/Config.zig)
- [Spectre compatibility policy](https://github.com/imrajyavardhan12/spectre-ghostty-config/blob/main/COMPATIBILITY.md)

The stable Ghostty target remains 1.3.1.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test -- --run` — 29 files, 378 tests
- [x] `bun run build`
- [x] `CI=1 bun run test:e2e` — 14 tests
- [x] `bun run schema:check` — live docs and pinned stable source matched 202/202 options
- [x] `git diff --check`

A read-only security/correctness review identified hydration sanitization and repeated-key complexity risks; both were corrected and covered by regression tests before this PR was opened.

## Visual evidence

No screenshot attached. The UI change is limited to text labels and source links in the existing import-review dialog; dialog behavior is covered by focused Testing Library tests and the import/export Playwright workflow.

## Checklist

- [x] The change is focused and does not include unrelated formatting or refactoring.
- [x] Tests cover observable behavior and important failure paths.
- [x] User-facing behavior and `CHANGELOG.md` are updated where needed.
- [x] Ghostty target changes update `compatibility.json` and `COMPATIBILITY.md` together. (Not applicable; target unchanged.)
- [x] UI changes were checked with keyboard/focus assertions and the full accessibility/mobile browser suite.
- [x] No secrets, personal configuration, or sensitive data are included.
- [x] I have read and followed `CONTRIBUTING.md` and the Code of Conduct.
