### PR TITLE
feat(import): preserve repeatable ordering, duplicates, resets, and paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Config file imports now open a review step before atomically replacing the current editor state.
 - Import review now supports explicit partial replacement when known values are invalid.
 - Unknown imported options are retained as visibly unverified strings, while unsafe or non-Ghostty-style option names are rejected before apply.
+- Import review now preserves source order within repeatable options, explains scalar winners and reset-cleared values, and applies Ghostty's file-level quote normalization and path marker behavior.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -237,6 +237,76 @@ test("a user can retain unverified options while unsafe names are rejected", asy
   await expect(output).not.toContainText("constructor =");
 });
 
+test("a user can review and apply duplicate, reset, repeatable, and path semantics", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import Config" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "text/plain",
+    buffer: Buffer.from(
+      'font-size = 14\nfont-size = 16\nfont-family = Before\nfont-family = ""\nfont-family = Primary\nfont-family = Fallback\nenv = BEFORE=1\nenv =\nenv = AFTER=2\nconfig-file = before\nconfig-file = """"\nconfig-file =\nconfig-file = ?after\n'
+    ),
+  });
+
+  await expect(page.getByText("12 accepted instructions")).toBeVisible();
+  await expect(page.getByText("8 effective instructions")).toBeVisible();
+
+  const imported = page.getByRole("list", { name: "Imported instructions" });
+  await expect(imported).toContainText("Line 2 font-size = 16");
+  const fontInstructions = imported
+    .getByRole("link", { name: "font-family", exact: true })
+    .locator("..");
+  await expect(fontInstructions).toHaveText([
+    /Line 4.*reset to default/,
+    /Line 5.*Primary/,
+    /Line 6.*Fallback/,
+  ]);
+  await expect(imported).toContainText("Line 8 env = (reset to default)");
+  await expect(imported).toContainText("Line 9 env = AFTER=2");
+  await expect(imported).toContainText(
+    "Line 12 config-file = (reset to default)"
+  );
+  await expect(imported).toContainText("Line 13 config-file = ?after");
+  await expect(
+    page.getByText(
+      "Repeatable values keep their order within each option. Export may regroup different option keys."
+    )
+  ).toBeVisible();
+
+  const issues = page.getByRole("list", { name: "Import issues" });
+  await expect(issues).toContainText("Line 1");
+  await expect(issues).toContainText("Source value: 14");
+  await expect(issues).toContainText("Source value: Before");
+  await expect(issues).toContainText('Source value: """"');
+
+  await page
+    .getByRole("button", { name: "Replace with 4 settings and skip 1 line" })
+    .click();
+  await expect(page.getByText("4 modified", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "View Config" }).click();
+  const output = page.locator("pre");
+  await expect(output).toContainText("font-size = 16");
+  await expect(output).toContainText("font-family = Primary");
+  await expect(output).toContainText("font-family = Fallback");
+  await expect(output).toContainText("env = AFTER=2");
+  await expect(output).toContainText("config-file = ?after");
+  await expect(output).not.toContainText("font-size = 14");
+  await expect(output).not.toContainText("font-family = Before");
+  await expect(output).not.toContainText("env = BEFORE=1");
+  await expect(output).not.toContainText("config-file = before");
+
+  const outputText = await output.textContent();
+  expect(outputText!.indexOf("font-family = Primary")).toBeLessThan(
+    outputText!.indexOf("font-family = Fallback")
+  );
+});
+
 test("a user can navigate and inspect configuration on a mobile screen", async ({
   page,
 }) => {

--- a/src/components/editor/ImportReviewDialog.test.tsx
+++ b/src/components/editor/ImportReviewDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ImportReviewDialog } from './ImportReviewDialog';
 import { analyzeGhosttyConfig } from '@/lib/utils/config-import-analysis';
 
@@ -140,6 +140,61 @@ future-option = third
     expect(screen.queryByText('future-option = second')).not.toBeInTheDocument();
     expectImportedInstruction('future-option', 'future-option = third');
     expectImportIssue(/Line 4.*Related lines: 2, 3\./);
+  });
+
+  it('shows effective order while keeping overridden, cleared, and ignored source values inspectable', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 14
+font-size = 16
+font-family = First
+font-family = Second
+font-family =
+font-family = After
+config-file = first
+config-file = """"
+config-file =`);
+
+    render(
+      <ImportReviewDialog
+        open
+        fileName="config"
+        fileSize={160}
+        currentSettingCount={0}
+        analysis={analysis}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('8 accepted instructions')).toBeInTheDocument();
+    expect(screen.getByText('4 effective instructions')).toBeInTheDocument();
+
+    const instructions = screen.getByRole('list', {
+      name: 'Imported instructions',
+    });
+    expect(instructions).toHaveTextContent('Line 2 font-size = 16');
+    expect(instructions).toHaveTextContent(
+      'Line 5 font-family = (reset to default)'
+    );
+    expect(instructions).toHaveTextContent('Line 6 font-family = After');
+    expect(instructions).toHaveTextContent(
+      'Line 9 config-file = (reset to default)'
+    );
+    expect(instructions).not.toHaveTextContent('font-size = 14');
+    expect(instructions).not.toHaveTextContent('font-family = First');
+    expect(instructions).not.toHaveTextContent('font-family = Second');
+    expect(within(instructions).getAllByRole('link', { name: 'font-family' })).toHaveLength(2);
+    expect(
+      screen.getByText(
+        'Repeatable values keep their order within each option. Export may regroup different option keys.'
+      )
+    ).toBeInTheDocument();
+
+    const issues = screen.getByRole('list', { name: 'Import issues' });
+    expect(issues).toHaveTextContent(/Line 1.*Source value: 14/);
+    expect(issues).toHaveTextContent(/Line 3.*Source value: First/);
+    expect(issues).toHaveTextContent(/Line 4.*Source value: Second/);
+    expect(issues).toHaveTextContent(/Line 7.*Source value: first/);
+    expect(issues).toHaveTextContent(/Line 8.*Source value: """"/);
   });
 
   it('shows invalid known values and explicit partial-import action copy', () => {

--- a/src/components/editor/ImportReviewDialog.tsx
+++ b/src/components/editor/ImportReviewDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { ConfigValues } from "@/lib/schema/types";
+import { isRepeatableOption } from "@/lib/utils/config-options";
 import type {
   ImportAnalysis,
   ImportDiagnostic,
@@ -85,6 +86,9 @@ export function ImportReviewDialog({
   const hasUnknownInstructions = effectiveInstructions.some(
     (instruction) => !instruction.known
   );
+  const hasRepeatableInstructions = effectiveInstructions.some(
+    (instruction) => instruction.known && isRepeatableOption(instruction.key)
+  );
   const resultingCount = analysis.summary.resultingSettingCount;
   const skippedCount = analysis.summary.skippedLineCount;
   const baseActionLabel = resultingCount === 0
@@ -99,7 +103,7 @@ export function ImportReviewDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[calc(100vh-2rem)] sm:max-w-2xl"
+        className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-2xl"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           cancelRef.current?.focus();
@@ -118,8 +122,17 @@ export function ImportReviewDialog({
             {fileName}
           </span>
           <span>{formatFileSize(fileSize)}</span>
-          <span>{analysis.summary.acceptedInstructionCount} accepted instructions</span>
-          <span>{resultingCount} resulting settings</span>
+          <span>
+            {analysis.summary.acceptedInstructionCount} accepted{" "}
+            {analysis.summary.acceptedInstructionCount === 1 ? "instruction" : "instructions"}
+          </span>
+          <span>
+            {analysis.summary.effectiveInstructionCount} effective{" "}
+            {analysis.summary.effectiveInstructionCount === 1 ? "instruction" : "instructions"}
+          </span>
+          <span>
+            {resultingCount} resulting {resultingCount === 1 ? "setting" : "settings"}
+          </span>
           {skippedCount > 0 && (
             <span>
               {skippedCount} skipped {skippedCount === 1 ? "line" : "lines"}
@@ -138,7 +151,7 @@ export function ImportReviewDialog({
                 <li key={`${instruction.lineNumber}-${instruction.key}`} className="break-words">
                   <span className="mr-2 text-muted-foreground">
                     Line {instruction.lineNumber}
-                  </span>
+                  </span>{" "}
                   <a
                     href={
                       instruction.known
@@ -163,6 +176,13 @@ export function ImportReviewDialog({
             </ol>
           ) : (
             <p className="text-sm text-muted-foreground">No usable instructions found.</p>
+          )}
+
+          {hasRepeatableInstructions && (
+            <p className="text-xs text-muted-foreground">
+              Repeatable values keep their order within each option. Export may regroup
+              different option keys.
+            </p>
           )}
 
           {hasUnknownInstructions && (
@@ -212,6 +232,15 @@ export function ImportReviewDialog({
                       </>
                     )}
                     {`: ${diagnostic.message}${formatRelatedLines(diagnostic)}`}
+                    {diagnostic.rawValue !== undefined && (
+                      <>
+                        {" Source value: "}
+                        <code>
+                          {diagnostic.rawValue === "" ? "(empty)" : diagnostic.rawValue}
+                        </code>
+                        .
+                      </>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/src/data/ghostty-options.test.ts
+++ b/src/data/ghostty-options.test.ts
@@ -44,6 +44,42 @@ describe('ghostty-options', () => {
       expect(uniqueIds.size).toBe(ids.length);
     });
 
+    it('should match Ghostty 1.3.1 repeatable option metadata', () => {
+      const repeatableIds = allOptions
+        .filter(
+          (option) =>
+            option.type === 'keybind' ||
+            option.type === 'palette' ||
+            ('repeatable' in option && option.repeatable === true)
+        )
+        .map((option) => option.id)
+        .sort();
+
+      expect(repeatableIds).toEqual([
+        'clipboard-codepoint-map',
+        'command-palette-entry',
+        'config-file',
+        'custom-shader',
+        'env',
+        'font-codepoint-map',
+        'font-family',
+        'font-family-bold',
+        'font-family-bold-italic',
+        'font-family-italic',
+        'font-feature',
+        'font-variation',
+        'font-variation-bold',
+        'font-variation-bold-italic',
+        'font-variation-italic',
+        'gtk-custom-css',
+        'input',
+        'key-remap',
+        'keybind',
+        'link',
+        'palette',
+      ]);
+    });
+
     it('should have safe Ghostty-style option ids', () => {
       for (const option of allOptions) {
         expect(isSafeConfigKey(option.id), option.id).toBe(true);

--- a/src/data/ghostty-options.ts
+++ b/src/data/ghostty-options.ts
@@ -20,6 +20,7 @@ const fontOptions: ConfigOption[] = [
     default: "",
     category: "fonts",
     placeholder: "",
+    repeatable: true,
   },
   {
     id: "font-family-italic",
@@ -29,6 +30,7 @@ const fontOptions: ConfigOption[] = [
     default: "",
     category: "fonts",
     placeholder: "",
+    repeatable: true,
   },
   {
     id: "font-family-bold-italic",
@@ -38,6 +40,7 @@ const fontOptions: ConfigOption[] = [
     default: "",
     category: "fonts",
     placeholder: "",
+    repeatable: true,
   },
   {
     id: "font-size",
@@ -127,6 +130,7 @@ const fontOptions: ConfigOption[] = [
     default: "",
     category: "fonts",
     placeholder: "calt,liga",
+    repeatable: true,
   },
   {
     id: "font-variation",
@@ -136,6 +140,7 @@ const fontOptions: ConfigOption[] = [
     default: "",
     category: "fonts",
     placeholder: "wght=400",
+    repeatable: true,
   },
   {
     id: "font-variation-bold",
@@ -144,6 +149,7 @@ const fontOptions: ConfigOption[] = [
     type: "string",
     default: "",
     category: "fonts",
+    repeatable: true,
   },
   {
     id: "font-variation-italic",
@@ -152,6 +158,7 @@ const fontOptions: ConfigOption[] = [
     type: "string",
     default: "",
     category: "fonts",
+    repeatable: true,
   },
   {
     id: "font-variation-bold-italic",
@@ -160,6 +167,7 @@ const fontOptions: ConfigOption[] = [
     type: "string",
     default: "",
     category: "fonts",
+    repeatable: true,
   },
   {
     id: "font-codepoint-map",
@@ -168,6 +176,7 @@ const fontOptions: ConfigOption[] = [
     type: "string",
     default: "",
     category: "fonts",
+    repeatable: true,
   },
 ];
 
@@ -1094,6 +1103,7 @@ const shellOptions: ConfigOption[] = [
     category: "shell",
     placeholder: "raw:Hello",
     sinceVersion: "1.3.0",
+    repeatable: true,
   },
   {
     id: "working-directory",

--- a/src/lib/store/config-store.test.ts
+++ b/src/lib/store/config-store.test.ts
@@ -378,17 +378,58 @@ gtk-custom-css = gtk/overrides.css
       expect(output).toContain('gtk-custom-css = gtk/overrides.css');
     });
 
+    it('should apply and export only effective repeatable values in per-key order', () => {
+      const configString = `
+font-family = Primary
+font-family = Fallback One
+env = BEFORE=1
+env = ""
+env = AFTER=2
+config-file = before
+config-file = """"
+config-file =
+config-file = ?after
+font-family = Fallback Two
+`;
+
+      act(() => {
+        applyConfigImport(configString);
+      });
+
+      const state = getStoreState();
+      expect(state.config['font-family']).toEqual([
+        'Primary',
+        'Fallback One',
+        'Fallback Two',
+      ]);
+      expect(state.config['env']).toBe('AFTER=2');
+      expect(state.config['config-file']).toBe('?after');
+
+      const lines = state.exportConfig().split('\n');
+      expect(lines.filter((line) => line.startsWith('font-family ='))).toEqual([
+        'font-family = Primary',
+        'font-family = "Fallback One"',
+        'font-family = "Fallback Two"',
+      ]);
+      expect(lines.filter((line) => line.startsWith('env ='))).toEqual([
+        'env = AFTER=2',
+      ]);
+      expect(lines.filter((line) => line.startsWith('config-file ='))).toEqual([
+        'config-file = ?after',
+      ]);
+    });
+
     it('should preserve Ghostty path optional marker semantics', () => {
       const configString = `
 config-file = first
-config-file = ""
+config-file = """"
 config-file = second
 config-file =
 config-file = after-reset
-gtk-custom-css = "?required.css"
+gtk-custom-css = ""?required.css""
 gtk-custom-css = ?optional.css
 custom-shader = first.glsl
-custom-shader = ""
+custom-shader = """"
 custom-shader = second.glsl
 custom-shader = reset
 custom-shader = ignore
@@ -415,7 +456,7 @@ custom-shader = ignore
       expect(output).not.toContain('config-file = first');
       expect(output).not.toContain('config-file = second');
       expect(output).toContain('config-file = after-reset');
-      expect(output).toContain('gtk-custom-css = "?required.css"');
+      expect(output).toContain('gtk-custom-css = ""?required.css""');
       expect(output).toContain('gtk-custom-css = ?optional.css');
       expect(output).toContain('custom-shader = first.glsl');
       expect(output).toContain('custom-shader = second.glsl');

--- a/src/lib/utils/config-export.test.ts
+++ b/src/lib/utils/config-export.test.ts
@@ -30,8 +30,12 @@ describe('exportGhosttyConfig', () => {
     expect(output).toContain('keybind = ctrl+shift+e=text:FOO=bar');
     expect(output).toContain('keybind = clear');
     expect(output).toContain('palette = 15=#ffffff');
-    expect(output).toContain('gtk-custom-css = "?required.css"');
+    expect(output).toContain('gtk-custom-css = ""?required.css""');
     expect(output).toContain('gtk-custom-css = ?optional.css');
+    expect(analyzeGhosttyConfig(output).candidateConfig['gtk-custom-css']).toEqual([
+      '"?required.css"',
+      '?optional.css',
+    ]);
     expect(output).toContain('unknown-option = "raw = value"');
   });
 

--- a/src/lib/utils/config-export.ts
+++ b/src/lib/utils/config-export.ts
@@ -19,8 +19,19 @@ function formatValue(key: string, value: unknown): string {
   }
 
   if (typeof value === "string") {
-    if (isPathOption(key) && (value.startsWith("?") || value.startsWith('"?'))) {
+    if (isPathOption(key) && value.startsWith("?")) {
       return value;
+    }
+
+    if (
+      isPathOption(key) &&
+      value.startsWith('"?') &&
+      value.endsWith('"')
+    ) {
+      // Ghostty's file iterator removes one outer quote pair before the path
+      // parser runs. Keep an inner pair so a leading ? remains a required-path
+      // character instead of becoming the optional-file marker.
+      return `"${value}"`;
     }
 
     if (value.includes(" ")) {

--- a/src/lib/utils/config-import-analysis.test.ts
+++ b/src/lib/utils/config-import-analysis.test.ts
@@ -197,6 +197,395 @@ cursor-style =
     expect(analysis.hasMeaningfulInstruction).toBe(true);
   });
 
+  it('retains the last valid scalar occurrence and relates overridden lines to each winner', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 14
+font-size = invalid
+font-size = 16
+cursor-style = bar
+cursor-style = underline`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'font-size': 16,
+      'cursor-style': 'underline',
+    });
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'overridden',
+      'invalid',
+      'retained',
+      'overridden',
+      'retained',
+    ]);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'duplicate-overridden'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        lineNumber: 1,
+        key: 'font-size',
+        rawValue: '14',
+        relatedLineNumbers: [3],
+        severity: 'warning',
+      }),
+      expect.objectContaining({
+        lineNumber: 4,
+        key: 'cursor-style',
+        rawValue: 'bar',
+        relatedLineNumbers: [5],
+        severity: 'warning',
+      }),
+    ]);
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-number',
+          lineNumber: 2,
+        }),
+      ])
+    );
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 4,
+      effectiveInstructionCount: 2,
+      skippedLineCount: 1,
+      resultingSettingCount: 2,
+    });
+  });
+
+  it('clears earlier scalar and repeatable values on explicit resets before retaining later values', () => {
+    const analysis = analyzeGhosttyConfig(`font-family = First
+font-family = Second
+font-size = 14
+font-family =
+font-size =
+font-family = After
+font-family = Fallback
+font-size = invalid`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'font-family': ['After', 'Fallback'],
+    });
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'overridden',
+      'overridden',
+      'overridden',
+      'reset',
+      'reset',
+      'retained',
+      'retained',
+      'invalid',
+    ]);
+
+    const cleared = analysis.diagnostics.filter(
+      (diagnostic) => diagnostic.code === 'reset-cleared-value'
+    );
+    expect(cleared).toEqual([
+      expect.objectContaining({
+        lineNumber: 1,
+        rawValue: 'First',
+        relatedLineNumbers: [4],
+      }),
+      expect.objectContaining({
+        lineNumber: 2,
+        rawValue: 'Second',
+        relatedLineNumbers: [4],
+      }),
+      expect.objectContaining({
+        lineNumber: 3,
+        rawValue: '14',
+        relatedLineNumbers: [5],
+      }),
+    ]);
+
+    const resets = analysis.diagnostics.filter(
+      (diagnostic) => diagnostic.code === 'explicit-reset'
+    );
+    expect(resets).toEqual([
+      expect.objectContaining({
+        severity: 'info',
+        lineNumber: 4,
+        key: 'font-family',
+        relatedLineNumbers: [1, 2],
+      }),
+      expect.objectContaining({
+        severity: 'info',
+        lineNumber: 5,
+        key: 'font-size',
+        relatedLineNumbers: [3],
+      }),
+    ]);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 7,
+      effectiveInstructionCount: 4,
+      skippedLineCount: 1,
+      resultingSettingCount: 1,
+    });
+  });
+
+  it('keeps each consecutive explicit reset meaningful for review', () => {
+    const analysis = analyzeGhosttyConfig(`font-size =
+font-size =`);
+
+    expect(analysis.candidateConfig).toEqual({});
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['reset', 'reset']);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 2,
+      effectiveInstructionCount: 2,
+      skippedLineCount: 0,
+      resultingSettingCount: 0,
+    });
+    expect(analysis.hasMeaningfulInstruction).toBe(true);
+  });
+
+  it('allows a later scalar value after an explicit reset', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 14
+font-size =
+font-size = 16`);
+
+    expect(analysis.candidateConfig['font-size']).toBe(16);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['overridden', 'reset', 'retained']);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 3,
+      effectiveInstructionCount: 2,
+      skippedLineCount: 0,
+      resultingSettingCount: 1,
+    });
+  });
+
+  it('applies Ghostty file-level double-quote removal before known empty resets', () => {
+    const analysis = analyzeGhosttyConfig(`font-family = Before
+font-family = ""
+font-family = After
+font-family = ''
+title = ""
+command = ''
+mouse-hide-while-typing = ""`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'font-family': ['After', "''"],
+      command: "''",
+    });
+    expect(analysis.normalizedConfig).toEqual(analysis.candidateConfig);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'overridden',
+      'reset',
+      'retained',
+      'retained',
+      'reset',
+      'retained',
+      'reset',
+    ]);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'explicit-reset'
+      )
+    ).toEqual([
+      expect.objectContaining({ lineNumber: 2, relatedLineNumbers: [1] }),
+      expect.objectContaining({ lineNumber: 5, relatedLineNumbers: [] }),
+      expect.objectContaining({ lineNumber: 7, relatedLineNumbers: [] }),
+    ]);
+    expect(analysis.summary.skippedLineCount).toBe(0);
+  });
+
+  it('lets a quoted empty scalar reset an earlier valid value', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 16
+font-size = ""`);
+
+    expect(analysis.candidateConfig).toEqual({});
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['overridden', 'reset']);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 2,
+      effectiveInstructionCount: 1,
+      skippedLineCount: 0,
+      resultingSettingCount: 0,
+    });
+  });
+
+  it.each([
+    ['font-family-bold', 'Bold One', 'Bold Two'],
+    ['font-family-italic', 'Italic One', 'Italic Two'],
+    ['font-family-bold-italic', 'Bold Italic One', 'Bold Italic Two'],
+    ['font-feature', 'calt', 'liga'],
+    ['font-variation', 'wght=400', 'wdth=90'],
+    ['font-variation-bold', 'wght=600', 'wdth=95'],
+    ['font-variation-italic', 'ital=1', 'slnt=-10'],
+    ['font-variation-bold-italic', 'wght=600', 'ital=1'],
+    ['font-codepoint-map', 'U+ABCD=Font One', 'U+1234=Font Two'],
+    ['input', 'raw:first', 'raw:second'],
+  ])('preserves repeated %s values in source order', (key, first, second) => {
+    const analysis = analyzeGhosttyConfig(
+      `${key} = ${first}\n${key} = ${second}`
+    );
+
+    expect(analysis.candidateConfig[key]).toEqual([first, second]);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['retained', 'retained']);
+    expect(
+      analysis.diagnostics.some(
+        (diagnostic) => diagnostic.code === 'duplicate-overridden'
+      )
+    ).toBe(false);
+  });
+
+  it('preserves relative order for effective font and environment occurrences', () => {
+    const analysis = analyzeGhosttyConfig(`font-family = Primary
+env = FIRST=1
+font-family = Fallback One
+env = SECOND=2
+font-family = Fallback Two
+env = ""
+env = AFTER=3`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'font-family': ['Primary', 'Fallback One', 'Fallback Two'],
+      env: 'AFTER=3',
+    });
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'retained',
+      'overridden',
+      'retained',
+      'overridden',
+      'retained',
+      'reset',
+      'retained',
+    ]);
+    expect(
+      analysis.instructions
+        .filter(
+          (instruction) =>
+            instruction.disposition === 'retained' ||
+            instruction.disposition === 'reset'
+        )
+        .map((instruction) => [
+          instruction.lineNumber,
+          instruction.key,
+          instruction.normalizedValue,
+        ])
+    ).toEqual([
+      [1, 'font-family', 'Primary'],
+      [3, 'font-family', 'Fallback One'],
+      [5, 'font-family', 'Fallback Two'],
+      [6, 'env', undefined],
+      [7, 'env', 'AFTER=3'],
+    ]);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 7,
+      effectiveInstructionCount: 5,
+      skippedLineCount: 0,
+      resultingSettingCount: 2,
+    });
+  });
+
+  it('preserves Ghostty file-level resets, nested required paths, and optional paths', () => {
+    const analysis = analyzeGhosttyConfig(`config-file = first
+config-file = ""
+config-file = second
+config-file =
+config-file = after-reset
+gtk-custom-css = "?quoted-optional.css"
+gtk-custom-css = ?optional.css
+custom-shader = """"
+custom-shader = ""?required.glsl""`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'config-file': 'after-reset',
+      'gtk-custom-css': ['?quoted-optional.css', '?optional.css'],
+      'custom-shader': '"?required.glsl"',
+    });
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'overridden',
+      'reset',
+      'overridden',
+      'reset',
+      'retained',
+      'retained',
+      'retained',
+      'ignored',
+      'retained',
+    ]);
+
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'quoted-empty-path-ignored'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        severity: 'info',
+        lineNumber: 8,
+        key: 'custom-shader',
+        rawValue: '""""',
+      }),
+    ]);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 8,
+      effectiveInstructionCount: 6,
+      skippedLineCount: 1,
+      resultingSettingCount: 3,
+    });
+  });
+
+  it('resets repeatable custom parsers after file-level quoted-empty normalization', () => {
+    const analysis = analyzeGhosttyConfig(`font-variation = wght=400
+font-variation = ""
+clipboard-codepoint-map = U+2500=U+002D
+clipboard-codepoint-map = ""`);
+
+    expect(analysis.candidateConfig).toEqual({});
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['overridden', 'reset', 'overridden', 'reset']);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'explicit-reset'
+      )
+    ).toEqual([
+      expect.objectContaining({ lineNumber: 2, relatedLineNumbers: [1] }),
+      expect.objectContaining({ lineNumber: 4, relatedLineNumbers: [3] }),
+    ]);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 4,
+      effectiveInstructionCount: 2,
+      skippedLineCount: 0,
+      resultingSettingCount: 0,
+    });
+  });
+
+  it('keeps an earlier valid scalar when a later occurrence is invalid', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 16
+font-size = invalid`);
+
+    expect(analysis.candidateConfig['font-size']).toBe(16);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual(['retained', 'invalid']);
+    expect(
+      analysis.diagnostics.some(
+        (diagnostic) => diagnostic.code === 'duplicate-overridden'
+      )
+    ).toBe(false);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 1,
+      effectiveInstructionCount: 1,
+      skippedLineCount: 1,
+    });
+  });
+
   it('parses Ghostty boolean tokens exactly and rejects other values', () => {
     const trueTokens = ['1', 't', 'T', 'true'];
     const falseTokens = ['0', 'f', 'F', 'false'];

--- a/src/lib/utils/config-import-analysis.ts
+++ b/src/lib/utils/config-import-analysis.ts
@@ -3,7 +3,11 @@ import {
   isSafeConfigKey,
   isUnsafeConfigKey,
 } from "@/lib/security/config-key-safety";
-import { getConfigOption, isPathOption } from "@/lib/utils/config-options";
+import {
+  getConfigOption,
+  isPathOption,
+  isRepeatableOption,
+} from "@/lib/utils/config-options";
 import {
   createConfigValues,
   normalizeConfigValues,
@@ -36,6 +40,10 @@ export type ImportDiagnosticCode =
   | "empty-key"
   | "unknown-option"
   | "unsafe-option-name"
+  | "duplicate-overridden"
+  | "reset-cleared-value"
+  | "explicit-reset"
+  | "quoted-empty-path-ignored"
   | "invalid-enum"
   | "invalid-color"
   | "invalid-duration";
@@ -45,6 +53,7 @@ export interface ImportDiagnostic {
   severity: "error" | "warning" | "info";
   lineNumber: number;
   key?: string;
+  rawValue?: string;
   message: string;
   relatedLineNumbers?: number[];
 }
@@ -281,9 +290,6 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
     }
 
     const option = getConfigOption(key);
-    const parsedPathValue = option && isPathOption(key)
-      ? parsePathValue(rawValue)
-      : null;
 
     if (!option && !isSafeConfigKey(key)) {
       instructions.push(invalidInstruction(lineNumber, key, rawValue, false));
@@ -332,18 +338,15 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
       return;
     }
 
-    if (parsedPathValue?.kind === "ignore") {
-      instructions.push({
-        lineNumber,
-        key,
-        rawValue,
-        disposition: "ignored",
-        known: true,
-      });
-      return;
-    }
+    // Ghostty's config-file iterator removes one pair of outer double quotes
+    // before dispatching a known value to the generic field parser. The field
+    // parser then treats the resulting empty string as a default reset.
+    const fileValue = stripDoubleQuotes(rawValue);
+    const parsedPathValue = isPathOption(key)
+      ? parsePathValue(fileValue)
+      : null;
 
-    if (rawValue === "" || parsedPathValue?.kind === "reset") {
+    if (fileValue === "" || parsedPathValue?.kind === "reset") {
       delete candidateConfig[key];
       instructions.push({
         lineNumber,
@@ -355,9 +358,29 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
       return;
     }
 
+    if (parsedPathValue?.kind === "ignore") {
+      instructions.push({
+        lineNumber,
+        key,
+        rawValue,
+        disposition: "ignored",
+        known: true,
+      });
+      diagnostics.push({
+        code: "quoted-empty-path-ignored",
+        severity: "info",
+        lineNumber,
+        key,
+        rawValue,
+        message:
+          "This path is empty after quote and optional-marker parsing, so Ghostty ignores it without resetting earlier paths.",
+      });
+      return;
+    }
+
     const value = parsedPathValue?.kind === "value"
       ? parsedPathValue.value
-      : stripMatchingQuotes(rawValue);
+      : fileValue;
     let normalizedValue: unknown = value;
     const rejectValue = (
       code: ImportDiagnosticCode,
@@ -475,6 +498,66 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
     });
   });
 
+  const activeKnownInstructionIndexes = new Map<string, number[]>();
+  instructions.forEach((instruction, index) => {
+    if (!instruction.known) return;
+
+    if (instruction.disposition === "reset") {
+      const clearedIndexes = activeKnownInstructionIndexes.get(instruction.key) ?? [];
+      const clearedLineNumbers = clearedIndexes.map(
+        (clearedIndex) => instructions[clearedIndex].lineNumber
+      );
+      for (const clearedIndex of clearedIndexes) {
+        const cleared = instructions[clearedIndex];
+        cleared.disposition = "overridden";
+        diagnostics.push({
+          code: "reset-cleared-value",
+          severity: "warning",
+          lineNumber: cleared.lineNumber,
+          key: instruction.key,
+          rawValue: cleared.rawValue,
+          message: `This value is cleared by the reset on line ${instruction.lineNumber}.`,
+          relatedLineNumbers: [instruction.lineNumber],
+        });
+      }
+      diagnostics.push({
+        code: "explicit-reset",
+        severity: "info",
+        lineNumber: instruction.lineNumber,
+        key: instruction.key,
+        rawValue: instruction.rawValue,
+        message: "This instruction resets the option to its Ghostty default.",
+        relatedLineNumbers: clearedLineNumbers,
+      });
+      activeKnownInstructionIndexes.set(instruction.key, []);
+      return;
+    }
+
+    if (instruction.disposition !== "retained") return;
+    const indexes = activeKnownInstructionIndexes.get(instruction.key) ?? [];
+    indexes.push(index);
+    activeKnownInstructionIndexes.set(instruction.key, indexes);
+  });
+
+  for (const [key, indexes] of activeKnownInstructionIndexes) {
+    if (isRepeatableOption(key)) continue;
+    if (indexes.length < 2) continue;
+    const winner = instructions[indexes[indexes.length - 1]];
+    for (const index of indexes.slice(0, -1)) {
+      const overridden = instructions[index];
+      overridden.disposition = "overridden";
+      diagnostics.push({
+        code: "duplicate-overridden",
+        severity: "warning",
+        lineNumber: overridden.lineNumber,
+        key,
+        rawValue: overridden.rawValue,
+        message: `A later valid value on line ${winner.lineNumber} wins.`,
+        relatedLineNumbers: [winner.lineNumber],
+      });
+    }
+  }
+
   for (const [key, occurrence] of unknownOptions) {
     diagnostics.push({
       code: "unknown-option",
@@ -495,7 +578,6 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
       instruction.disposition === "overridden" ||
       instruction.disposition === "reset"
   ).length;
-  // Known scalar override classification is added by the duplicate/order slice (#69).
   const effectiveInstructionCount = instructions.filter(
     (instruction) =>
       instruction.disposition === "retained" ||

--- a/src/lib/utils/config-import.test.ts
+++ b/src/lib/utils/config-import.test.ts
@@ -37,14 +37,14 @@ future-option = "second value"
   it('preserves Ghostty path optional marker semantics', () => {
     const config = parseGhosttyConfig(`
 config-file = first
-config-file = ""
+config-file = """"
 config-file = second
 config-file =
 config-file = after-reset
-gtk-custom-css = "?required.css"
+gtk-custom-css = ""?required.css""
 gtk-custom-css = ?optional.css
 custom-shader = first.glsl
-custom-shader = ""
+custom-shader = """"
 custom-shader = second.glsl
 `);
 


### PR DESCRIPTION
## Summary

- preserve relative source order for every Ghostty 1.3.1 repeatable option and correct missing repeatable metadata for ten schema entries
- classify scalar duplicates, retain the last valid winner, and keep invalid later occurrences from erasing valid values
- make overridden, reset-cleared, ignored, reset, and retained instructions inspectable with raw source values and related line numbers
- expose canonical accepted/effective counts and explain that export may regroup different keys while preserving per-key order
- preserve optional and required `?` path semantics through import/export and keep long review dialogs operable

## Related issue

Closes #69

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring or maintenance
- [x] Ghostty compatibility update

## Ghostty source of truth

- [Ghostty configuration reference](https://ghostty.org/docs/config/reference)
- [Pinned Ghostty 1.3.1 `Config.zig`](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/config/Config.zig)
- [Pinned configuration-file line iterator and generic field parser](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/cli/args.zig)
- [Pinned path parser](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/config/path.zig)

The source audit clarified an important file-level rule: Ghostty removes one outer double-quote pair before known field parsing, so `key = ""` resets just like an unquoted empty RHS. A path that must remain quoted for path-level empty/required-`?` behavior therefore needs an inner quote pair after that preprocessing. The implementation and tests follow the pinned loader pipeline rather than isolated type parsers. The stable target remains Ghostty 1.3.1.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test -- --run` — 29 files, 401 tests
- [x] `bun run build`
- [x] `CI=1 bun run test:e2e` — 15 tests
- [x] `bun run schema:check` — live docs and pinned stable source matched 202/202 options
- [x] `git diff --check`

A read-only correctness review identified file-level quoted-empty and path preprocessing mismatches in the first implementation. Both were corrected against pinned Ghostty source and covered by focused import/export regressions before this PR was opened.

## Visual evidence

No screenshot attached. The UI changes add effective-count and diagnostic text to the existing import-review dialog; focused Testing Library coverage and the full Playwright import workflow verify the rendered behavior and long-dialog action reachability.

## Checklist

- [x] The change is focused and does not include unrelated formatting or refactoring.
- [x] Tests cover observable behavior and important failure paths.
- [x] User-facing behavior and `CHANGELOG.md` are updated where needed.
- [x] Ghostty target changes update `compatibility.json` and `COMPATIBILITY.md` together. (Not applicable; target unchanged.)
- [x] UI changes were checked with keyboard/focus assertions and the full accessibility/mobile browser suite.
- [x] No secrets, personal configuration, or sensitive data are included.
- [x] I have read and followed `CONTRIBUTING.md` and the Code of Conduct.
