### PR TITLE
feat(import): validate palette, keybind, and config-file instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Import review now supports explicit partial replacement when known values are invalid.
 - Unknown imported options are retained as visibly unverified strings, while unsafe or non-Ghostty-style option names are rejected before apply.
 - Import review now preserves source order within repeatable options, explains scalar winners and reset-cleared values, and applies Ghostty's file-level quote normalization and path marker behavior.
+- Structured imports now validate Ghostty palette and keybind syntax, retain future-compatible keybind actions as runtime-unverified, and disclose that referenced `config-file` paths are not read by Spectre.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -307,6 +307,75 @@ test("a user can review and apply duplicate, reset, repeatable, and path semanti
   );
 });
 
+test("a user can review structured palette, keybind, and config-file instructions", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import Config" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "text/plain",
+    buffer: Buffer.from(
+      'palette = 0=ffffff\npalette = red\npalette = 1=not-a-color\nkeybind = clear\nkeybind = chain=goto_split:left\nkeybind = resize/ctrl+h=resize_split:left,10\nkeybind = resize/\nkeybind = ctrl+/=new_tab\nkeybind = ctrl+shift+x=future_action:arg\nkeybind = ctrl+ctrl+c=new_tab\nconfig-file = "?optional"\nconfig-file = ""?required""\n'
+    ),
+  });
+
+  await expect(page.getByText("9 accepted instructions")).toBeVisible();
+  const imported = page.getByRole("list", { name: "Imported instructions" });
+  await expect(imported).toContainText("palette = 0=#ffffff");
+  await expect(imported).toContainText("keybind = clear");
+  await expect(imported).toContainText("keybind = chain=goto_split:left");
+  await expect(imported).toContainText(
+    "keybind = resize/ctrl+h=resize_split:left,10"
+  );
+  await expect(imported).toContainText("keybind = resize/");
+  await expect(imported).toContainText("keybind = ctrl+/=new_tab");
+  await expect(imported).toContainText(
+    "keybind = ctrl+shift+x=future_action:arg"
+  );
+  await expect(
+    page.getByRole("note", { name: "Included config files were not read" })
+  ).toContainText("Counts cover only the selected file");
+
+  const issues = page.getByRole("list", { name: "Import issues" });
+  await expect(issues).toContainText("Line 2");
+  await expect(issues).toContainText("Use Ghostty palette syntax N=COLOR");
+  await expect(issues).toContainText("Line 3");
+  await expect(issues).toContainText("named X11 color");
+  await expect(issues).toContainText('Action "future_action"');
+  await expect(issues).toContainText("runtime support is unverified");
+  await expect(issues).toContainText("Line 10");
+  await expect(issues).toContainText("Duplicate modifier");
+
+  await page
+    .getByRole("button", { name: "Replace with 3 settings and skip 3 lines" })
+    .click();
+  await expect(page.getByText("3 modified", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "View Config" }).click();
+  const output = page.locator("pre");
+  await expect(output).toContainText("palette = 0=#ffffff");
+  await expect(output).toContainText("keybind = clear");
+  await expect(output).toContainText("keybind = ctrl+/=new_tab");
+  await expect(output).toContainText("keybind = ctrl+shift+x=future_action:arg");
+  await expect(output).toContainText("config-file = ?optional");
+  await expect(output).toContainText('config-file = ""?required""');
+  await expect(output).not.toContainText("palette = red");
+  await expect(output).not.toContainText("palette = 1=not-a-color");
+  await expect(output).not.toContainText("ctrl+ctrl+c=new_tab");
+
+  const outputText = await output.textContent();
+  expect(outputText!.indexOf("keybind = clear")).toBeLessThan(
+    outputText!.indexOf("keybind = chain=goto_split:left")
+  );
+  expect(outputText!.indexOf("keybind = chain=goto_split:left")).toBeLessThan(
+    outputText!.indexOf("keybind = resize/ctrl+h=resize_split:left,10")
+  );
+});
+
 test("a user can navigate and inspect configuration on a mobile screen", async ({
   page,
 }) => {

--- a/src/components/editor/ImportReviewDialog.test.tsx
+++ b/src/components/editor/ImportReviewDialog.test.tsx
@@ -197,6 +197,72 @@ config-file =`);
     expect(issues).toHaveTextContent(/Line 8.*Source value: """"/);
   });
 
+  it('reviews normalized palettes and ordered keybinds while exposing invalid lines', () => {
+    const analysis = analyzeGhosttyConfig(`palette = 0=ffffff
+palette = red
+keybind = clear
+keybind = ctrl+/=new_tab
+keybind = ctrl+ctrl+c=new_tab
+config-file = ?optional`);
+
+    render(
+      <ImportReviewDialog
+        open
+        fileName="config"
+        fileSize={128}
+        currentSettingCount={0}
+        analysis={analysis}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const instructions = screen.getByRole('list', {
+      name: 'Imported instructions',
+    });
+    expect(instructions).toHaveTextContent('palette = 0=#ffffff');
+    expect(instructions).toHaveTextContent('keybind = clear');
+    expect(instructions).toHaveTextContent('keybind = ctrl+/=new_tab');
+    expect(instructions).not.toHaveTextContent('palette = red');
+    expect(instructions).not.toHaveTextContent('ctrl+ctrl+c=new_tab');
+    expectImportIssue(/Line 2.*Use Ghostty palette syntax N=COLOR/);
+    expectImportIssue(/Line 5.*Duplicate modifier/);
+    expect(
+      screen.getByRole('button', {
+        name: 'Replace with 3 settings and skip 2 lines',
+      })
+    ).toBeEnabled();
+  });
+
+  it('discloses that included config files were not read', () => {
+    const analysis = analyzeGhosttyConfig(`font-size = 16
+config-file = ?optional
+config-file = ""?required""`);
+
+    render(
+      <ImportReviewDialog
+        open
+        fileName="config"
+        fileSize={96}
+        currentSettingCount={0}
+        analysis={analysis}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('note', { name: 'Included config files were not read' })
+    ).toHaveTextContent(
+      "Spectre did not read referenced config files. Counts cover only the selected file, not Ghostty's final effective configuration after includes."
+    );
+    expect(
+      screen.getAllByRole('link', { name: 'config-file' })
+    ).toHaveLength(2);
+    expectImportIssue(/Line 2.*Ghostty may load it.*Source value: \?optional/);
+    expectImportIssue(/Line 3.*Ghostty may load it.*Source value: ""\?required""/);
+  });
+
   it('shows invalid known values and explicit partial-import action copy', () => {
     const analysis = analyzeGhosttyConfig(`
 font-size = 16

--- a/src/components/editor/ImportReviewDialog.tsx
+++ b/src/components/editor/ImportReviewDialog.tsx
@@ -89,6 +89,9 @@ export function ImportReviewDialog({
   const hasRepeatableInstructions = effectiveInstructions.some(
     (instruction) => instruction.known && isRepeatableOption(instruction.key)
   );
+  const hasUnresolvedConfigFiles = analysis.diagnostics.some(
+    (diagnostic) => diagnostic.code === "config-file-not-resolved"
+  );
   const resultingCount = analysis.summary.resultingSettingCount;
   const skippedCount = analysis.summary.skippedLineCount;
   const baseActionLabel = resultingCount === 0
@@ -183,6 +186,17 @@ export function ImportReviewDialog({
               Repeatable values keep their order within each option. Export may regroup
               different option keys.
             </p>
+          )}
+
+          {hasUnresolvedConfigFiles && (
+            <div
+              role="note"
+              aria-label="Included config files were not read"
+              className="rounded-md border border-blue-500/30 bg-blue-500/10 p-2 text-xs text-foreground"
+            >
+              Spectre did not read referenced config files. Counts cover only the selected
+              file, not Ghostty&apos;s final effective configuration after includes.
+            </div>
           )}
 
           {hasUnknownInstructions && (

--- a/src/lib/utils/config-import-analysis.test.ts
+++ b/src/lib/utils/config-import-analysis.test.ts
@@ -771,6 +771,215 @@ search-foreground = cell-background
     expect(invalid.diagnostics[0].code).toBe('invalid-color');
   });
 
+  it('retains effective config-file directives without resolving included files', () => {
+    const analysis = analyzeGhosttyConfig(`config-file = base
+font-size = 16
+config-file = "?quoted-optional"
+config-file = ""
+config-file = ?after
+config-file = ""?required""`);
+
+    expect(analysis.candidateConfig).toEqual({
+      'font-size': 16,
+      'config-file': ['?after', '"?required"'],
+    });
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'overridden',
+      'retained',
+      'overridden',
+      'reset',
+      'retained',
+      'retained',
+    ]);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'config-file-not-resolved'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        severity: 'info',
+        lineNumber: 5,
+        key: 'config-file',
+        rawValue: '?after',
+      }),
+      expect.objectContaining({
+        severity: 'info',
+        lineNumber: 6,
+        key: 'config-file',
+        rawValue: '""?required""',
+      }),
+    ]);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 6,
+      effectiveInstructionCount: 4,
+      skippedLineCount: 0,
+      resultingSettingCount: 2,
+    });
+  });
+
+  it('preserves supported keybind forms and excludes invalid syntax without blocking future actions', () => {
+    const analysis = analyzeGhosttyConfig(`keybind = clear
+keybind = chain=goto_split:left
+keybind = resize/ctrl+h=resize_split:left,10
+keybind = resize/
+keybind = ctrl+/=new_tab
+keybind = ctrl+a=copy_to_clipboard
+keybind = ctrl+a=copy_to_clipboard
+keybind = ctrl+shift+x=future_action:arg
+keybind = ctrl+x=future action
+keybind = ctrl+c copy_to_clipboard
+keybind = ctrl+ctrl+c=new_tab
+keybind = chain=
+keybind = global:chain=goto_split:left
+keybind = resize/chain=goto_split:left`);
+
+    expect(analysis.candidateConfig.keybind).toEqual([
+      'clear',
+      'chain=goto_split:left',
+      'resize/ctrl+h=resize_split:left,10',
+      'resize/',
+      'ctrl+/=new_tab',
+      'ctrl+a=copy_to_clipboard',
+      'ctrl+a=copy_to_clipboard',
+      'ctrl+shift+x=future_action:arg',
+    ]);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+    ]);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'invalid-keybind'
+      )
+    ).toHaveLength(6);
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'keybind-runtime-dependent',
+          severity: 'warning',
+          lineNumber: 8,
+          key: 'keybind',
+        }),
+      ])
+    );
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 8,
+      effectiveInstructionCount: 8,
+      skippedLineCount: 6,
+      resultingSettingCount: 1,
+    });
+  });
+
+  it('imports equals and plus key triggers while rejecting invalid parameters, sequences, and flags', () => {
+    const analysis = analyzeGhosttyConfig(`keybind = ctrl+==new_tab
+keybind = ==text:=hello
+keybind = ctrl+==text:
+keybind = ctrl++=new_tab
+keybind = ctrl+x=goto_split:banana
+keybind = ctrl+x=new_tab:garbage
+keybind = ctrl+x>>c=new_tab
+keybind = global:global:ctrl+a=new_tab`);
+
+    expect(analysis.candidateConfig.keybind).toEqual([
+      'ctrl+==new_tab',
+      '==text:=hello',
+      'ctrl+==text:',
+      'ctrl++=new_tab',
+    ]);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+    ]);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.code === 'invalid-keybind'
+      )
+    ).toHaveLength(4);
+    expect(analysis.summary).toMatchObject({
+      acceptedInstructionCount: 4,
+      effectiveInstructionCount: 4,
+      skippedLineCount: 4,
+    });
+  });
+
+  it('requires and validates Ghostty index=color palette syntax without positional fallback', () => {
+    const analysis = analyzeGhosttyConfig(`palette = 0=ffffff
+palette = 0b10=red
+palette = 0o10=#123
+palette = "0xF=medium spring green"
+palette = +1=blue
+palette = 1_0=yellow
+palette = #ffffff
+palette = nope=#ffffff
+palette = 256=#ffffff
+palette = 1=
+palette = 2=not-a-color
+palette = 3=cell-foreground`);
+
+    expect(analysis.candidateConfig.palette).toEqual([
+      '0=#ffffff',
+      '2=red',
+      '8=#123',
+      '15=medium spring green',
+      '1=blue',
+      '10=yellow',
+    ]);
+    expect(
+      analysis.instructions.map((instruction) => instruction.disposition)
+    ).toEqual([
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'retained',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+      'invalid',
+    ]);
+    expect(analysis.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'palette-missing-separator',
+      'invalid-palette-index',
+      'invalid-palette-index',
+      'empty-palette-color',
+      'invalid-palette-color',
+      'invalid-palette-color',
+    ]);
+    expect(analysis.summary).toEqual({
+      acceptedInstructionCount: 6,
+      effectiveInstructionCount: 6,
+      skippedLineCount: 6,
+      resultingSettingCount: 1,
+    });
+  });
+
   it('accepts Ghostty custom icon color lists', () => {
     const valid = analyzeGhosttyConfig(
       'macos-icon-screen-color = #112233, medium spring green, abc'

--- a/src/lib/utils/config-import-analysis.ts
+++ b/src/lib/utils/config-import-analysis.ts
@@ -12,7 +12,12 @@ import {
   createConfigValues,
   normalizeConfigValues,
 } from "@/lib/utils/config-normalization";
-import { validateConfigValue } from "@/lib/utils/config-validation";
+import {
+  validateConfigValue,
+  validateGhosttyColor,
+} from "@/lib/utils/config-validation";
+import { parsePaletteEntryDetailed } from "@/lib/utils/palette";
+import { validateImportedKeybind } from "@/lib/utils/keybind-validation";
 
 export type ImportInstructionDisposition =
   | "retained"
@@ -44,6 +49,14 @@ export type ImportDiagnosticCode =
   | "reset-cleared-value"
   | "explicit-reset"
   | "quoted-empty-path-ignored"
+  | "palette-missing-separator"
+  | "invalid-palette-index"
+  | "empty-palette-color"
+  | "invalid-palette-color"
+  | "invalid-keybind"
+  | "keybind-warning"
+  | "keybind-runtime-dependent"
+  | "config-file-not-resolved"
   | "invalid-enum"
   | "invalid-color"
   | "invalid-duration";
@@ -392,6 +405,7 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
         severity: "error",
         lineNumber,
         key,
+        rawValue,
         message,
       });
     };
@@ -473,10 +487,68 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
         candidateConfig[key] = normalizedValue;
         break;
       }
-      case "keybind":
-      case "palette":
+      case "keybind": {
+        const validation = validateImportedKeybind(value);
+        if (!validation.valid) {
+          rejectValue("invalid-keybind", validation.errors.join(" "));
+          return;
+        }
         appendValue(candidateConfig, key, value);
+        const runtimeWarnings = new Set(
+          validation.runtimeDependentWarnings
+        );
+        for (const warning of validation.warnings) {
+          diagnostics.push({
+            code: runtimeWarnings.has(warning)
+              ? "keybind-runtime-dependent"
+              : "keybind-warning",
+            severity: "warning",
+            lineNumber,
+            key,
+            rawValue,
+            message: warning,
+          });
+        }
         break;
+      }
+      case "palette": {
+        const parsed = parsePaletteEntryDetailed(value);
+        if (parsed.status === "missing-separator") {
+          rejectValue(
+            "palette-missing-separator",
+            "Use Ghostty palette syntax N=COLOR."
+          );
+          return;
+        }
+        if (parsed.status === "invalid-index") {
+          rejectValue(
+            "invalid-palette-index",
+            "Use a palette index from 0 through 255 in decimal, binary, octal, or hexadecimal form."
+          );
+          return;
+        }
+        if (parsed.status === "empty-color") {
+          rejectValue("empty-palette-color", "Enter a palette color after =.");
+          return;
+        }
+
+        const colorValidation = validateGhosttyColor(parsed.entry.color);
+        if (!colorValidation.valid) {
+          rejectValue(
+            "invalid-palette-color",
+            colorValidation.errors.join(" ")
+          );
+          return;
+        }
+
+        const color = String(
+          colorValidation.normalizedValue ?? parsed.entry.color
+        );
+        const normalizedEntry = `${parsed.entry.index}=${color}`;
+        normalizedValue = normalizedEntry;
+        appendValue(candidateConfig, key, normalizedEntry);
+        break;
+      }
       case "string":
         if (option.repeatable) {
           appendValue(candidateConfig, key, value, false);
@@ -556,6 +628,24 @@ export function analyzeGhosttyConfig(configString: string): ImportAnalysis {
         relatedLineNumbers: [winner.lineNumber],
       });
     }
+  }
+
+  for (const instruction of instructions) {
+    if (
+      instruction.key !== "config-file" ||
+      instruction.disposition !== "retained"
+    ) {
+      continue;
+    }
+    diagnostics.push({
+      code: "config-file-not-resolved",
+      severity: "info",
+      lineNumber: instruction.lineNumber,
+      key: instruction.key,
+      rawValue: instruction.rawValue,
+      message:
+        "Spectre did not read this referenced file. Ghostty may load it and change the final effective configuration at runtime.",
+    });
   }
 
   for (const [key, occurrence] of unknownOptions) {

--- a/src/lib/utils/config-import.test.ts
+++ b/src/lib/utils/config-import.test.ts
@@ -21,7 +21,7 @@ unknown-option = "raw = value"
       'ctrl+shift+e=text:FOO=bar',
       'clear',
     ]);
-    expect(config.palette).toEqual(['0b10=red']);
+    expect(config.palette).toEqual(['2=red']);
     expect(config['unknown-option']).toBe('raw = value');
   });
 

--- a/src/lib/utils/config-validation.test.ts
+++ b/src/lib/utils/config-validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { validateConfigValue } from '@/lib/utils/config-validation';
+import {
+  validateConfigValue,
+  validateGhosttyColor,
+} from '@/lib/utils/config-validation';
 import type { ColorOption, DurationOption, NumberOption } from '@/lib/schema/types';
 
 const colorOption: ColorOption = {
@@ -34,6 +37,13 @@ const numberOption: NumberOption = {
 };
 
 describe('validateConfigValue', () => {
+  it('validates general Ghostty colors without terminal-relative extensions', () => {
+    expect(validateGhosttyColor('#abc').valid).toBe(true);
+    expect(validateGhosttyColor('medium spring green').valid).toBe(true);
+    expect(validateGhosttyColor('cell-foreground').valid).toBe(false);
+    expect(validateGhosttyColor('not-a-color').valid).toBe(false);
+  });
+
   it('accepts Ghostty color syntax from docs and source', () => {
     expect(validateConfigValue(colorOption, '#aabbcc').valid).toBe(true);
     expect(validateConfigValue(colorOption, 'aabbcc').valid).toBe(true);

--- a/src/lib/utils/config-validation.ts
+++ b/src/lib/utils/config-validation.ts
@@ -42,6 +42,19 @@ function isGhosttyColor(value: string): boolean {
   );
 }
 
+export function validateGhosttyColor(value: unknown): ConfigValidationResult {
+  if (typeof value !== "string") {
+    return invalid(["Enter a color value."]);
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") return valid("");
+  if (isGhosttyColor(trimmedValue)) return valid(trimmedValue);
+  return invalid([
+    "Use #RGB, RGB, #RRGGBB, RRGGBB, or a named X11 color.",
+  ]);
+}
+
 function validateColorValue(
   option: ConfigOption,
   value: unknown
@@ -72,9 +85,8 @@ function validateColorValue(
     ]);
   }
 
-  if (isGhosttyColor(trimmedValue)) {
-    return valid(trimmedValue);
-  }
+  const colorValidation = validateGhosttyColor(trimmedValue);
+  if (colorValidation.valid) return colorValidation;
 
   if (
     TERMINAL_RELATIVE_COLOR_OPTIONS.has(option.id) &&
@@ -83,11 +95,11 @@ function validateColorValue(
     return valid(trimmedValue);
   }
 
-  return invalid([
-    TERMINAL_RELATIVE_COLOR_OPTIONS.has(option.id)
-      ? "Use #RGB, RGB, #RRGGBB, RRGGBB, a named X11 color, cell-foreground, or cell-background."
-      : "Use #RGB, RGB, #RRGGBB, RRGGBB, or a named X11 color.",
-  ]);
+  return TERMINAL_RELATIVE_COLOR_OPTIONS.has(option.id)
+    ? invalid([
+        "Use #RGB, RGB, #RRGGBB, RRGGBB, a named X11 color, cell-foreground, or cell-background.",
+      ])
+    : colorValidation;
 }
 
 function readUnsignedInteger(input: string, startIndex: number) {

--- a/src/lib/utils/keybind-validation.test.ts
+++ b/src/lib/utils/keybind-validation.test.ts
@@ -4,6 +4,7 @@ import {
   validateTriggerSequence,
   validateAction,
   validateKeybind,
+  validateImportedKeybind,
   KEYBIND_ACTIONS,
   getActionSuggestions,
   KEYBIND_EXAMPLES,
@@ -315,6 +316,53 @@ describe('keybind-validation', () => {
       const result = validateKeybind('resize/chain=goto_split:left');
       expect(result.valid).toBe(false);
       expect(result.errors).toContain('Chained actions cannot be prefixed with a key table');
+    });
+  });
+
+  describe('validateImportedKeybind', () => {
+    it('accepts future-compatible action names with valid keybind structure', () => {
+      const result = validateImportedKeybind(
+        'ctrl+shift+x=future_action:argument'
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.warnings).toEqual([
+        'Action "future_action" is not in Spectre\'s Ghostty target. Ghostty runtime support is unverified.',
+      ]);
+    });
+
+    it('accepts equals-key triggers and empty string actions from Ghostty syntax', () => {
+      for (const keybind of [
+        'ctrl+==new_tab',
+        '==text:=hello',
+        'ctrl+==text:',
+        'ctrl++=new_tab',
+        'global:+=new_tab',
+      ]) {
+        expect(validateImportedKeybind(keybind).valid, keybind).toBe(true);
+      }
+    });
+
+    it('rejects malformed future actions and known actions missing required parameters', () => {
+      expect(validateImportedKeybind('ctrl+x=future action').valid).toBe(false);
+      expect(validateImportedKeybind('ctrl+x=text').valid).toBe(false);
+    });
+
+    it('rejects invalid known parameters, empty sequence parts, and duplicate flags', () => {
+      for (const keybind of [
+        'ctrl+x=goto_split:banana',
+        'ctrl+x=new_tab:garbage',
+        'ctrl+x>>c=new_tab',
+        'global:global:ctrl+a=new_tab',
+        'global::ctrl+a=new_tab',
+        ':ctrl+a=new_tab',
+        'global:=new_tab',
+        'global:ctrl+a>ctrl+b=new_tab',
+        'all:ctrl+a>ctrl+b=new_tab',
+      ]) {
+        expect(validateImportedKeybind(keybind).valid, keybind).toBe(false);
+      }
     });
   });
 

--- a/src/lib/utils/keybind-validation.ts
+++ b/src/lib/utils/keybind-validation.ts
@@ -631,8 +631,10 @@ export function validateTrigger(trigger: string): TriggerValidation {
     return { ...result, valid: false, error: "Trigger cannot be empty" };
   }
 
-  // Split by + to get parts
-  const parts = trigger.toLowerCase().split("+").map(p => p.trim()).filter(p => p);
+  // Split by + while preserving internal empty parts: Ghostty uses an empty
+  // part to represent the literal + key (for example, ctrl++).
+  const parts = trigger.toLowerCase().split("+").map((part) => part.trim());
+  if (parts[parts.length - 1] === "") parts.pop();
 
   if (parts.length === 0) {
     return { ...result, valid: false, error: "Invalid trigger format" };
@@ -645,23 +647,32 @@ export function validateTrigger(trigger: string): TriggerValidation {
     // All but the last are prefixes
     for (let i = 0; i < prefixParts.length - 1; i++) {
       const prefix = prefixParts[i].trim();
-      if (prefix && !TRIGGER_PREFIXES.has(prefix)) {
+      if (!prefix) {
+        return { ...result, valid: false, error: "Prefix cannot be empty" };
+      }
+      if (!TRIGGER_PREFIXES.has(prefix)) {
         return { ...result, valid: false, error: `Invalid prefix: "${prefix}". Valid prefixes: ${Array.from(TRIGGER_PREFIXES).join(", ")}` };
       }
-      if (prefix) {
-        result.prefixes.push(prefix);
+      if (result.prefixes.includes(prefix)) {
+        return { ...result, valid: false, error: `Duplicate prefix: "${prefix}"` };
       }
+      result.prefixes.push(prefix);
     }
-    // Replace first part with the last segment (the actual key/modifier)
-    parts[0] = prefixParts[prefixParts.length - 1].trim();
+    // Replace first part with the last segment (the actual key/modifier).
+    // A trailing + is the literal plus key; other empty trigger segments fail.
+    const triggerPart = prefixParts[prefixParts.length - 1].trim();
+    if (!triggerPart && !trigger.trim().endsWith("+")) {
+      return { ...result, valid: false, error: "Trigger cannot be empty" };
+    }
+    parts[0] = triggerPart;
   }
 
   // Track modifiers we've seen to detect duplicates
   const seenModifiers = new Set<string>();
   let keyFound = false;
 
-  for (const part of parts) {
-    if (!part) continue;
+  for (const rawPart of parts) {
+    const part = rawPart === "" ? "+" : rawPart;
 
     // Check if it's a modifier
     if (VALID_MODIFIERS.has(part)) {
@@ -716,8 +727,18 @@ export function validateTriggerSequence(triggerSeq: string): TriggerSequenceVali
     return { valid: false, error: "Trigger cannot be empty", sequences: [] };
   }
 
-  // Split by > to get individual triggers in the sequence
-  const triggerParts = triggerSeq.split(">").map(t => t.trim()).filter(t => t);
+  // Split by > to get individual triggers in the sequence. Empty parts are
+  // invalid rather than silently disappearing (a>>b, >a, and a>).
+  const triggerParts = triggerSeq.split(">").map((trigger) => trigger.trim());
+
+  if (triggerParts.some((trigger) => trigger === "")) {
+    const emptyIndex = triggerParts.findIndex((trigger) => trigger === "");
+    return {
+      valid: false,
+      error: `Sequence part ${emptyIndex + 1}: Trigger cannot be empty`,
+      sequences: [],
+    };
+  }
 
   if (triggerParts.length === 0) {
     return { valid: false, error: "Invalid trigger format", sequences: [] };
@@ -733,6 +754,20 @@ export function validateTriggerSequence(triggerSeq: string): TriggerSequenceVali
       result.error = `Sequence part ${i + 1}: ${validation.error}`;
       break;
     }
+  }
+
+  if (
+    result.valid &&
+    triggerParts.length > 1 &&
+    result.sequences.some((trigger) =>
+      trigger.prefixes.some((prefix) => prefix === "global" || prefix === "all")
+    )
+  ) {
+    return {
+      ...result,
+      valid: false,
+      error: "Global and all prefixes cannot be used with trigger sequences",
+    };
   }
 
   return result;
@@ -798,15 +833,39 @@ export function validateAction(actionStr: string): ActionValidation {
     };
   }
 
-  // Check if action requires param
-  const actionDef = KEYBIND_ACTIONS.find(a => a.action === result.action);
-  const requiresParam = actionDef?.hasParam && actionDef.paramRequired !== false;
-  if (requiresParam && !result.param) {
+  const actionDef = KEYBIND_ACTIONS.find((action) => action.action === result.action)!;
+  const hasParameter = colonIndex !== -1;
+  if (!actionDef.hasParam && hasParameter) {
     return {
       ...result,
       valid: false,
-      error: `Action "${result.action}" requires a parameter (${actionDef.paramDesc})`,
+      error: `Action "${result.action}" does not accept a parameter`,
     };
+  }
+
+  if (actionDef.hasParam) {
+    const requiresParam = actionDef.paramRequired !== false;
+    if (!hasParameter || (result.param === "" && !EMPTY_PARAMETER_ACTIONS.has(result.action))) {
+      if (requiresParam || hasParameter) {
+        return {
+          ...result,
+          valid: false,
+          error: `Action "${result.action}" requires a parameter (${actionDef.paramDesc})`,
+        };
+      }
+    }
+
+    if (
+      result.param !== undefined &&
+      actionDef.paramOptions &&
+      !actionDef.paramOptions.includes(result.param)
+    ) {
+      return {
+        ...result,
+        valid: false,
+        error: `Action "${result.action}" parameter must be one of: ${actionDef.paramOptions.join(", ")}`,
+      };
+    }
   }
 
   return result;
@@ -815,6 +874,32 @@ export function validateAction(actionStr: string): ActionValidation {
 interface KeyTableBinding {
   binding: string;
   bindingWithAction: string;
+}
+
+const EMPTY_PARAMETER_ACTIONS = new Set([
+  "activate_key_table",
+  "activate_key_table_once",
+  "csi",
+  "esc",
+  "search",
+  "set_surface_title",
+  "set_tab_title",
+  "text",
+]);
+
+function findKeybindDelimiter(input: string): number {
+  let offset = 0;
+  while (offset < input.length) {
+    const equalsIndex = input.indexOf("=", offset);
+    if (equalsIndex === -1) return -1;
+    const next = input[equalsIndex + 1];
+    if (next === "+" || next === "=") {
+      offset = equalsIndex + 1;
+      continue;
+    }
+    return equalsIndex;
+  }
+  return -1;
 }
 
 function parseKeyTableBinding(input: string, equalsIndex: number): KeyTableBinding | null {
@@ -880,7 +965,7 @@ export function validateKeybind(keybind: string): ValidationResult {
     return result;
   }
 
-  const equalsIndex = trimmedKeybind.indexOf("=");
+  const equalsIndex = findKeybindDelimiter(trimmedKeybind);
   const tableBinding = parseKeyTableBinding(trimmedKeybind, equalsIndex);
 
   if (equalsIndex === -1) {
@@ -927,6 +1012,43 @@ export function validateKeybind(keybind: string): ValidationResult {
   addActionErrorsAndWarnings(result, action);
 
   return result;
+}
+
+const FUTURE_ACTION_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+const UNKNOWN_ACTION_ERROR_PATTERN = /^Unknown action: "([^"]+)"$/;
+
+/**
+ * Validate source-file keybind syntax without coupling imports to Spectre's
+ * pinned action-name list. Structurally valid future action names remain
+ * reviewable; known actions still receive their parameter validation.
+ */
+export interface ImportedKeybindValidationResult extends ValidationResult {
+  runtimeDependentWarnings: string[];
+}
+
+export function validateImportedKeybind(
+  keybind: string
+): ImportedKeybindValidationResult {
+  const validation = validateKeybind(keybind);
+  const runtimeWarnings: string[] = [];
+  const errors = validation.errors.filter((error) => {
+    const unknownAction = error.match(UNKNOWN_ACTION_ERROR_PATTERN);
+    if (!unknownAction || !FUTURE_ACTION_NAME_PATTERN.test(unknownAction[1])) {
+      return true;
+    }
+
+    runtimeWarnings.push(
+      `Action "${unknownAction[1]}" is not in Spectre's Ghostty target. Ghostty runtime support is unverified.`
+    );
+    return false;
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings: [...validation.warnings, ...runtimeWarnings],
+    runtimeDependentWarnings: runtimeWarnings,
+  };
 }
 
 // Helper to get autocomplete suggestions for actions

--- a/src/lib/utils/palette.test.ts
+++ b/src/lib/utils/palette.test.ts
@@ -3,6 +3,7 @@ import {
   getPaletteColor,
   normalizePaletteEntries,
   parsePaletteEntry,
+  parsePaletteEntryDetailed,
   setPaletteColor,
 } from '@/lib/utils/palette';
 
@@ -13,10 +14,28 @@ describe('palette utilities', () => {
       expect(parsePaletteEntry('5=#BB78D9')).toEqual({ index: 5, color: '#BB78D9' });
     });
 
-    it('parses binary, octal, and hexadecimal palette indexes from Ghostty syntax', () => {
-      expect(parsePaletteEntry('0b101=#111111')).toEqual({ index: 5, color: '#111111' });
-      expect(parsePaletteEntry('0o10=#222222')).toEqual({ index: 8, color: '#222222' });
+    it('parses signed and separated Ghostty palette indexes across supported bases', () => {
+      expect(parsePaletteEntry('+1=#010101')).toEqual({ index: 1, color: '#010101' });
+      expect(parsePaletteEntry('-0=#000000')).toEqual({ index: 0, color: '#000000' });
+      expect(parsePaletteEntry('1_0=#101010')).toEqual({ index: 10, color: '#101010' });
+      expect(parsePaletteEntry('0b1_01=#111111')).toEqual({ index: 5, color: '#111111' });
+      expect(parsePaletteEntry('0o1_0=#222222')).toEqual({ index: 8, color: '#222222' });
       expect(parsePaletteEntry('0xF=#333333')).toEqual({ index: 15, color: '#333333' });
+    });
+
+    it('distinguishes malformed source-file palette fields', () => {
+      expect(parsePaletteEntryDetailed('#ffffff')).toEqual({
+        status: 'missing-separator',
+      });
+      expect(parsePaletteEntryDetailed('nope=#ffffff')).toEqual({
+        status: 'invalid-index',
+      });
+      expect(parsePaletteEntryDetailed('256=#ffffff')).toEqual({
+        status: 'invalid-index',
+      });
+      expect(parsePaletteEntryDetailed('15=')).toEqual({
+        status: 'empty-color',
+      });
     });
 
     it('returns null for invalid or out-of-range entries', () => {

--- a/src/lib/utils/palette.ts
+++ b/src/lib/utils/palette.ts
@@ -8,30 +8,47 @@ export interface ParsedPaletteEntry {
   color: string;
 }
 
+export type PaletteEntryParseResult =
+  | { status: "valid"; entry: ParsedPaletteEntry }
+  | { status: "missing-separator" }
+  | { status: "invalid-index" }
+  | { status: "empty-color" };
+
 const HEX_COLOR_WITHOUT_HASH = /^[0-9a-f]{6}$/i;
 const MIN_PALETTE_INDEX = 0;
 const MAX_PALETTE_INDEX = 255;
 
 function parsePaletteIndex(rawIndex: string): number | null {
-  const token = rawIndex.trim().toLowerCase();
-
-  if (/^0b[01]+$/.test(token)) {
-    return parseInt(token.slice(2), 2);
+  let token = rawIndex.trim().toLowerCase();
+  let negative = false;
+  if (token.startsWith("+") || token.startsWith("-")) {
+    negative = token[0] === "-";
+    token = token.slice(1);
   }
 
-  if (/^0o[0-7]+$/.test(token)) {
-    return parseInt(token.slice(2), 8);
+  let base = 10;
+  let digitPattern = /^[0-9]+$/;
+  if (token.startsWith("0b")) {
+    base = 2;
+    digitPattern = /^[01]+$/;
+    token = token.slice(2);
+  } else if (token.startsWith("0o")) {
+    base = 8;
+    digitPattern = /^[0-7]+$/;
+    token = token.slice(2);
+  } else if (token.startsWith("0x")) {
+    base = 16;
+    digitPattern = /^[0-9a-f]+$/;
+    token = token.slice(2);
   }
 
-  if (/^0x[0-9a-f]+$/.test(token)) {
-    return parseInt(token.slice(2), 16);
-  }
+  if (!token || token.startsWith("_") || token.endsWith("_")) return null;
+  const digits = token.replaceAll("_", "");
+  if (!digitPattern.test(digits)) return null;
 
-  if (/^\d+$/.test(token)) {
-    return parseInt(token, 10);
-  }
-
-  return null;
+  const parsed = parseInt(digits, base);
+  if (negative && parsed !== 0) return null;
+  return parsed;
 }
 
 export function normalizePaletteColor(color: string): string {
@@ -39,20 +56,26 @@ export function normalizePaletteColor(color: string): string {
   return HEX_COLOR_WITHOUT_HASH.test(trimmed) ? `#${trimmed}` : trimmed;
 }
 
-export function parsePaletteEntry(entry: string): ParsedPaletteEntry | null {
+export function parsePaletteEntryDetailed(entry: string): PaletteEntryParseResult {
   const equalsIndex = entry.indexOf("=");
-  if (equalsIndex === -1) return null;
+  if (equalsIndex === -1) return { status: "missing-separator" };
 
   const rawIndex = entry.slice(0, equalsIndex);
   const rawColor = entry.slice(equalsIndex + 1);
   const index = parsePaletteIndex(rawIndex);
-  const color = normalizePaletteColor(rawColor);
-
-  if (index === null || index < MIN_PALETTE_INDEX || index > MAX_PALETTE_INDEX || !color) {
-    return null;
+  if (index === null || index < MIN_PALETTE_INDEX || index > MAX_PALETTE_INDEX) {
+    return { status: "invalid-index" };
   }
 
-  return { index, color };
+  const color = normalizePaletteColor(rawColor);
+  if (!color) return { status: "empty-color" };
+
+  return { status: "valid", entry: { index, color } };
+}
+
+export function parsePaletteEntry(entry: string): ParsedPaletteEntry | null {
+  const result = parsePaletteEntryDetailed(entry);
+  return result.status === "valid" ? result.entry : null;
 }
 
 export function normalizePaletteEntries(entries: string[]): string[] {


### PR DESCRIPTION
## Summary

- require imported palettes to use Ghostty `N=COLOR` syntax and emit distinct stable diagnostics for missing separators, invalid indexes, empty colors, and invalid colors
- normalize decimal/binary/octal/hex palette indexes with Ghostty-compatible signs and underscore separators while keeping legacy positional fallback limited to existing editor data
- preserve ordered keybind `clear`, chains, key tables, table clears, slash/equals/plus triggers, repeated bindings, and empty string actions
- reject malformed keybind parameters, sequences, and flags while retaining structurally valid future actions with an explicit runtime-unverified warning
- retain effective `config-file` path/reset order without reading included files, and disclose that review counts cover only the selected file

## Related issue

Closes #70

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring or maintenance
- [x] Ghostty compatibility update

## Ghostty source of truth

- [Ghostty configuration reference](https://ghostty.org/docs/config/reference)
- [Ghostty keybind reference](https://ghostty.org/docs/config/keybind/reference)
- [Pinned Ghostty 1.3.1 palette parser](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/config/Config.zig)
- [Pinned Ghostty 1.3.1 binding parser](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/input/Binding.zig)
- [Pinned Ghostty 1.3.1 path parser](https://github.com/ghostty-org/ghostty/blob/332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28/src/config/path.zig)
- [Zig 0.15.2 integer parser](https://github.com/ziglang/zig/blob/0.15.2/lib/std/fmt.zig)

The stable Ghostty target remains 1.3.1. Validation is intentionally split between syntax Spectre can verify and action/path/include behavior that depends on the user's Ghostty runtime.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test -- --run` — 29 files, 413 tests
- [x] `bun run build`
- [x] `CI=1 bun run test:e2e` — 16 tests
- [x] `bun run schema:check` — live docs and pinned stable source matched 202/202 options
- [x] `git diff --check`

A read-only correctness review identified valid equals/plus keybindings being rejected, malformed parameters/sequences/flags being accepted, and valid signed/separated palette indexes being rejected. These findings and the warning-classification suggestion were corrected and covered by regressions before this PR was opened.

## Visual evidence

No screenshot attached. The UI change adds a local-only include disclosure to the existing import-review dialog; focused Testing Library coverage and the Playwright structured-import workflow verify the rendered behavior.

## Checklist

- [x] The change is focused and does not include unrelated formatting or refactoring.
- [x] Tests cover observable behavior and important failure paths.
- [x] User-facing behavior and `CHANGELOG.md` are updated where needed.
- [x] Ghostty target changes update `compatibility.json` and `COMPATIBILITY.md` together. (Not applicable; target unchanged.)
- [x] UI changes were checked with keyboard/focus assertions and the full accessibility/mobile browser suite.
- [x] No secrets, personal configuration, or sensitive data are included.
- [x] I have read and followed `CONTRIBUTING.md` and the Code of Conduct.
