### PR TITLE
feat(import): harden file ingestion and stale reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Unknown imported options are retained as visibly unverified strings, while unsafe or non-Ghostty-style option names are rejected before apply.
 - Import review now preserves source order within repeatable options, explains scalar winners and reset-cleared values, and applies Ghostty's file-level quote normalization and path marker behavior.
 - Structured imports now validate Ghostty palette and keybind syntax, retain future-compatible keybind actions as runtime-unverified, and disclose that referenced `config-file` paths are not read by Spectre.
+- Browser imports now reject oversized, pathological, binary, and unreadable files locally, and stale asynchronous selections can no longer publish the wrong review or error.
 - Switched Dependabot to its Bun ecosystem so dependency updates include the committed `bun.lock` file.
 - Declared the repository's Bun package-manager version in `package.json` for consistent local and CI tooling.
 - Removed the unusable Prettier script; formatter adoption will be handled separately from functional changes.

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { expect, test, type Route } from "@playwright/test";
 import compatibility from "../compatibility.json";
 import { encodeConfig } from "../src/lib/utils/url-share";
+import { IMPORT_FILE_LIMITS } from "../src/lib/utils/config-import-file";
 
 test("a user can open the configuration editor", async ({ page }) => {
   await page.goto("/");
@@ -374,6 +375,57 @@ test("a user can review structured palette, keybind, and config-file instruction
   expect(outputText!.indexOf("keybind = chain=goto_split:left")).toBeLessThan(
     outputText!.indexOf("keybind = resize/ctrl+h=resize_split:left,10")
   );
+});
+
+test("a user can recover from a rejected config file without reloading", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fontSize = page.locator('#option-font-size input[type="number"]');
+  await fontSize.fill("16");
+
+  const importButton = page.getByRole("button", { name: "Import Config" });
+  let fileChooserPromise = page.waitForEvent("filechooser");
+  await importButton.click();
+  let fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "too-large",
+    mimeType: "application/octet-stream",
+    buffer: Buffer.alloc(IMPORT_FILE_LIMITS.maxBytes + 1, "x"),
+  });
+
+  await expect(
+    page
+      .getByRole("alert")
+      .filter({ hasText: "Choose a config file no larger than 1 MiB." })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Review imported configuration" })
+  ).not.toBeVisible();
+  await expect(fontSize).toHaveValue("16");
+
+  fileChooserPromise = page.waitForEvent("filechooser");
+  await importButton.click();
+  fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "",
+    buffer: Buffer.from("font-size = 18\n"),
+  });
+
+  await expect(
+    page.getByRole("heading", { name: "Review imported configuration" })
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole("alert")
+      .filter({ hasText: "Choose a config file no larger than 1 MiB." })
+  ).not.toBeAttached();
+  await expect(fontSize).toHaveValue("16");
+
+  await page.getByRole("button", { name: "Replace with 1 setting" }).click();
+  await expect(fontSize).toHaveValue("18");
 });
 
 test("a user can navigate and inspect configuration on a mobile screen", async ({

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Ghost, Code2, Download, Upload, RotateCcw, Check, Loader2, Palette, Sparkles, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,17 +14,12 @@ import { useConfigStore } from "@/lib/store/config-store";
 import { ImportReviewDialog } from "@/components/editor/ImportReviewDialog";
 import { PresetsDialog } from "@/components/editor/PresetsDialog";
 import { cn } from "@/lib/utils";
-import { analyzeGhosttyConfig } from "@/lib/utils/config-import-analysis";
-import type { ImportAnalysis } from "@/lib/utils/config-import-analysis";
+import {
+  ImportFileCoordinator,
+  type PendingImportFile,
+} from "@/lib/utils/config-import-coordinator";
 import type { ConfigValues } from "@/lib/schema/types";
 import { SPECTRE_VERSION } from "@/lib/version";
-
-interface PendingImport {
-  fileName: string;
-  fileSize: number;
-  currentSettingCount: number;
-  analysis: ImportAnalysis;
-}
 
 export function Header() {
   // Use selectors to properly subscribe to config changes
@@ -35,8 +30,52 @@ export function Header() {
   const [exportState, setExportState] = useState<"idle" | "loading" | "success">("idle");
   const [importState, setImportState] = useState<"idle" | "loading" | "success">("idle");
   const [importStatusMessage, setImportStatusMessage] = useState("");
-  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const [importErrorMessage, setImportErrorMessage] = useState("");
+  const [pendingImport, setPendingImport] = useState<PendingImportFile | null>(null);
   const importButtonRef = useRef<HTMLButtonElement>(null);
+  const importFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const importCoordinatorRef = useRef<ImportFileCoordinator | null>(null);
+
+  const clearImportFeedbackTimer = () => {
+    if (importFeedbackTimerRef.current !== null) {
+      clearTimeout(importFeedbackTimerRef.current);
+      importFeedbackTimerRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    const coordinator = new ImportFileCoordinator({
+      getCurrentSettingCount: () =>
+        Object.keys(useConfigStore.getState().config).length,
+      onStart: () => {
+        if (importFeedbackTimerRef.current !== null) {
+          clearTimeout(importFeedbackTimerRef.current);
+          importFeedbackTimerRef.current = null;
+        }
+        setPendingImport(null);
+        setImportStatusMessage("");
+        setImportErrorMessage("");
+        setImportState("loading");
+      },
+      onSuccess: (pending) => {
+        setPendingImport(pending);
+        setImportState("idle");
+      },
+      onError: (error) => {
+        setImportErrorMessage(error.message);
+        setImportState("idle");
+      },
+    });
+    importCoordinatorRef.current = coordinator;
+
+    return () => {
+      coordinator.cancel();
+      importCoordinatorRef.current = null;
+      if (importFeedbackTimerRef.current !== null) {
+        clearTimeout(importFeedbackTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleExport = async () => {
     setExportState("loading");
@@ -62,22 +101,9 @@ export function Header() {
   const handleImport = () => {
     const input = document.createElement("input");
     input.type = "file";
-    input.onchange = async (e) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (file) {
-        setImportState("loading");
-        try {
-          const text = await file.text();
-          setPendingImport({
-            fileName: file.name,
-            fileSize: file.size,
-            currentSettingCount: Object.keys(useConfigStore.getState().config).length,
-            analysis: analyzeGhosttyConfig(text),
-          });
-        } finally {
-          setImportState("idle");
-        }
-      }
+    input.onchange = (event) => {
+      const file = (event.target as HTMLInputElement).files?.[0];
+      if (file) void importCoordinatorRef.current?.select(file);
     };
     input.click();
   };
@@ -96,6 +122,7 @@ export function Header() {
     const skippedCount = pendingImport?.analysis.summary.skippedLineCount ?? 0;
     useConfigStore.getState().applyImportedCandidate(candidate);
     setPendingImport(null);
+    setImportErrorMessage("");
     setImportState("success");
     const resultMessage = resultingCount === 0
       ? "Imported configuration defaults"
@@ -105,9 +132,11 @@ export function Header() {
       : "";
     setImportStatusMessage(`${resultMessage}${skippedMessage}.`);
     restoreImportFocus();
-    setTimeout(() => {
+    clearImportFeedbackTimer();
+    importFeedbackTimerRef.current = setTimeout(() => {
       setImportState("idle");
       setImportStatusMessage("");
+      importFeedbackTimerRef.current = null;
     }, 2000);
   };
 
@@ -322,6 +351,11 @@ export function Header() {
       <p className="sr-only" role="status" aria-live="polite">
         {importStatusMessage}
       </p>
+      {importErrorMessage && (
+        <p className="sr-only" role="alert">
+          {importErrorMessage}
+        </p>
+      )}
     </header>
   );
 }

--- a/src/lib/utils/config-import-coordinator.test.ts
+++ b/src/lib/utils/config-import-coordinator.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+
+const analysisControl = vi.hoisted(() => ({ throwOnAnalyze: false }));
+
+vi.mock("@/lib/utils/config-import-analysis", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/utils/config-import-analysis")>();
+  return {
+    ...actual,
+    analyzeGhosttyConfig: (source: string) => {
+      if (analysisControl.throwOnAnalyze) {
+        throw new Error("unexpected analyzer failure");
+      }
+      return actual.analyzeGhosttyConfig(source);
+    },
+  };
+});
+
+import {
+  ImportFileCoordinator,
+  type PendingImportFile,
+} from "@/lib/utils/config-import-coordinator";
+import {
+  IMPORT_FILE_LIMITS,
+  type ImportFileError,
+  type ImportFileLike,
+} from "@/lib/utils/config-import-file";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createCoordinator() {
+  const onStart = vi.fn<(token: number) => void>();
+  const onSuccess = vi.fn<(pending: PendingImportFile) => void>();
+  const onError = vi.fn<(error: ImportFileError) => void>();
+  const coordinator = new ImportFileCoordinator({
+    getCurrentSettingCount: () => 3,
+    onStart,
+    onSuccess,
+    onError,
+  });
+
+  return { coordinator, onStart, onSuccess, onError };
+}
+
+describe("ImportFileCoordinator", () => {
+  it("publishes only the newest deferred file analysis", async () => {
+    const firstRead = deferred<string>();
+    const secondRead = deferred<string>();
+    const first: ImportFileLike = {
+      name: "first-config",
+      size: 16,
+      text: () => firstRead.promise,
+    };
+    const second: ImportFileLike = {
+      name: "config",
+      size: 16,
+      text: () => secondRead.promise,
+    };
+    const { coordinator, onStart, onSuccess, onError } = createCoordinator();
+
+    const firstTask = coordinator.select(first);
+    const secondTask = coordinator.select(second);
+    secondRead.resolve("font-size = 18");
+    await secondTask;
+    firstRead.resolve("font-size = 14");
+    await firstTask;
+
+    expect(onStart.mock.calls.map(([token]) => token)).toEqual([1, 2]);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "config",
+        currentSettingCount: 3,
+      })
+    );
+    expect(onSuccess.mock.calls[0][0].analysis.candidateConfig["font-size"]).toBe(18);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not publish a stale read error after a newer success", async () => {
+    const firstRead = deferred<string>();
+    const secondRead = deferred<string>();
+    const { coordinator, onSuccess, onError } = createCoordinator();
+
+    const firstTask = coordinator.select({
+      name: "unreadable",
+      size: 16,
+      text: () => firstRead.promise,
+    });
+    const secondTask = coordinator.select({
+      name: "config",
+      size: 16,
+      text: () => secondRead.promise,
+    });
+    secondRead.resolve("font-size = 18");
+    await secondTask;
+    firstRead.reject(new DOMException("Denied", "NotReadableError"));
+    await firstTask;
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not publish a stale validation error after a newer success", async () => {
+    const firstRead = deferred<string>();
+    const secondRead = deferred<string>();
+    const { coordinator, onSuccess, onError } = createCoordinator();
+
+    const firstTask = coordinator.select({
+      name: "binary",
+      size: 16,
+      text: () => firstRead.promise,
+    });
+    const secondTask = coordinator.select({
+      name: "config",
+      size: 16,
+      text: () => secondRead.promise,
+    });
+    secondRead.resolve("font-size = 18");
+    await secondTask;
+    firstRead.resolve("font-size = \0");
+    await firstTask;
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a current rejection on the next selection", async () => {
+    const { coordinator, onStart, onSuccess, onError } = createCoordinator();
+    const oversizedText = vi.fn(async () => "not read");
+
+    await coordinator.select({
+      name: "too-large",
+      size: IMPORT_FILE_LIMITS.maxBytes + 1,
+      text: oversizedText,
+    });
+    await coordinator.select({
+      name: "config",
+      size: 16,
+      text: async () => "font-size = 18",
+    });
+
+    expect(oversizedText).not.toHaveBeenCalled();
+    expect(onStart.mock.calls.map(([token]) => token)).toEqual([1, 2]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "file-too-large" })
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a local error when analysis throws unexpectedly", async () => {
+    analysisControl.throwOnAnalyze = true;
+    const { coordinator, onSuccess, onError } = createCoordinator();
+    try {
+      await coordinator.select({
+        name: "config",
+        size: 16,
+        text: async () => "font-size = 18",
+      });
+    } finally {
+      analysisControl.throwOnAnalyze = false;
+    }
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "file-read-failed" })
+    );
+  });
+
+  it("invalidates an in-flight selection when canceled", async () => {
+    const read = deferred<string>();
+    const { coordinator, onSuccess, onError } = createCoordinator();
+    const task = coordinator.select({
+      name: "config",
+      size: 16,
+      text: () => read.promise,
+    });
+
+    coordinator.cancel();
+    read.resolve("font-size = 18");
+    await task;
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/utils/config-import-coordinator.ts
+++ b/src/lib/utils/config-import-coordinator.ts
@@ -1,0 +1,57 @@
+import type { ImportAnalysis } from "@/lib/utils/config-import-analysis";
+import {
+  analyzeImportFile,
+  type ImportFileError,
+  type ImportFileLike,
+} from "@/lib/utils/config-import-file";
+
+export interface PendingImportFile {
+  fileName: string;
+  fileSize: number;
+  currentSettingCount: number;
+  analysis: ImportAnalysis;
+}
+
+interface ImportFileCoordinatorHandlers {
+  getCurrentSettingCount: () => number;
+  onStart: (token: number) => void;
+  onSuccess: (pending: PendingImportFile) => void;
+  onError: (error: ImportFileError) => void;
+}
+
+export class ImportFileCoordinator {
+  private latestToken = 0;
+
+  constructor(private readonly handlers: ImportFileCoordinatorHandlers) {}
+
+  async select(file: ImportFileLike): Promise<void> {
+    const token = ++this.latestToken;
+    this.handlers.onStart(token);
+
+    const result = await analyzeImportFile(
+      file,
+      () => token === this.latestToken
+    );
+
+    // The await above is an asynchronous publication boundary even when a
+    // synchronous size rejection resolved the promise. Never publish an older
+    // result after a newer selection has started.
+    if (token !== this.latestToken || result.status === "stale") return;
+
+    if (result.status === "error") {
+      this.handlers.onError(result.error);
+      return;
+    }
+
+    this.handlers.onSuccess({
+      fileName: result.fileName,
+      fileSize: result.fileSize,
+      currentSettingCount: this.handlers.getCurrentSettingCount(),
+      analysis: result.analysis,
+    });
+  }
+
+  cancel(): void {
+    this.latestToken += 1;
+  }
+}

--- a/src/lib/utils/config-import-file.test.ts
+++ b/src/lib/utils/config-import-file.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  IMPORT_FILE_LIMITS,
+  analyzeImportFile,
+  validateImportSourceText,
+  type ImportFileLike,
+} from "@/lib/utils/config-import-file";
+
+function createFile(
+  overrides: Partial<ImportFileLike> = {}
+): ImportFileLike {
+  return {
+    name: "config",
+    size: 32,
+    text: vi.fn(async () => "font-size = 16"),
+    ...overrides,
+  };
+}
+
+describe("config import file analysis", () => {
+  it("accepts an extensionless config at the exact byte limit", async () => {
+    const file = createFile({ size: IMPORT_FILE_LIMITS.maxBytes });
+
+    const result = await analyzeImportFile(file);
+
+    expect(result.status).toBe("success");
+    if (result.status !== "success") return;
+    expect(result.fileName).toBe("config");
+    expect(result.fileSize).toBe(IMPORT_FILE_LIMITS.maxBytes);
+    expect(result.analysis.candidateConfig["font-size"]).toBe(16);
+    expect(file.text).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects one byte over the limit before reading", async () => {
+    const file = createFile({ size: IMPORT_FILE_LIMITS.maxBytes + 1 });
+
+    const result = await analyzeImportFile(file);
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: { code: "file-too-large" },
+    });
+    expect(file.text).not.toHaveBeenCalled();
+  });
+
+  it("enforces exact line-count and line-length boundaries", () => {
+    const tenThousandLines = Array.from(
+      { length: IMPORT_FILE_LIMITS.maxLines },
+      () => "#"
+    ).join("\n");
+    const tenThousandAndOneLines = `${tenThousandLines}\n#`;
+    const longestLine = "x".repeat(IMPORT_FILE_LIMITS.maxLineLength);
+    const overlongLine = `${longestLine}x`;
+
+    expect(validateImportSourceText(tenThousandLines)).toBeNull();
+    expect(validateImportSourceText(tenThousandAndOneLines)).toMatchObject({
+      code: "too-many-lines",
+    });
+    expect(validateImportSourceText(longestLine)).toBeNull();
+    expect(validateImportSourceText(overlongLine)).toMatchObject({
+      code: "line-too-long",
+    });
+  });
+
+  it("counts a trailing newline as a terminator, not an extra line", () => {
+    const tenThousandTerminated =
+      `${Array.from({ length: IMPORT_FILE_LIMITS.maxLines }, () => "#").join("\n")}\n`;
+    const tenThousandAndOneTerminated = `${tenThousandTerminated}#\n`;
+
+    expect(validateImportSourceText("")).toBeNull();
+    expect(validateImportSourceText(tenThousandTerminated)).toBeNull();
+    expect(validateImportSourceText(tenThousandAndOneTerminated)).toMatchObject({
+      code: "too-many-lines",
+    });
+  });
+
+  it.each([
+    ["start", "\0font-size = 16"],
+    ["middle", "font\0-size = 16"],
+    ["end", "font-size = 16\0"],
+  ])("rejects a NUL byte at the %s", (_position, source) => {
+    expect(validateImportSourceText(source)).toMatchObject({
+      code: "likely-binary",
+    });
+  });
+
+  it("rejects over-limit line counts and lengths through the full file path", async () => {
+    const tooManyLines = `${"#\n".repeat(IMPORT_FILE_LIMITS.maxLines)}#`;
+    const tooLongLine = "x".repeat(IMPORT_FILE_LIMITS.maxLineLength + 1);
+
+    for (const source of [tooManyLines, tooLongLine]) {
+      const file = createFile({
+        size: source.length,
+        text: async () => source,
+      });
+      const result = await analyzeImportFile(file);
+      expect(result.status).toBe("error");
+    }
+  });
+
+  it("returns a local error when the browser cannot read the file", async () => {
+    const file = createFile({
+      text: vi.fn(async () => {
+        throw new DOMException("Denied", "NotReadableError");
+      }),
+    });
+
+    const result = await analyzeImportFile(file);
+
+    expect(result).toMatchObject({
+      status: "error",
+      error: { code: "file-read-failed" },
+    });
+  });
+});

--- a/src/lib/utils/config-import-file.ts
+++ b/src/lib/utils/config-import-file.ts
@@ -1,0 +1,137 @@
+import type { ImportAnalysis } from "@/lib/utils/config-import-analysis";
+import { analyzeGhosttyConfig } from "@/lib/utils/config-import-analysis";
+
+export const IMPORT_FILE_LIMITS = {
+  maxBytes: 1_048_576,
+  maxLines: 10_000,
+  maxLineLength: 65_536,
+} as const;
+
+export interface ImportFileLike {
+  name: string;
+  size: number;
+  text: () => Promise<string>;
+}
+
+export type ImportFileErrorCode =
+  | "file-too-large"
+  | "too-many-lines"
+  | "line-too-long"
+  | "likely-binary"
+  | "file-read-failed";
+
+export interface ImportFileError {
+  code: ImportFileErrorCode;
+  message: string;
+}
+
+export type ImportFileAnalysisResult =
+  | {
+      status: "success";
+      fileName: string;
+      fileSize: number;
+      analysis: ImportAnalysis;
+    }
+  | { status: "error"; error: ImportFileError }
+  | { status: "stale" };
+
+const FILE_TOO_LARGE: ImportFileError = {
+  code: "file-too-large",
+  message: "Choose a config file no larger than 1 MiB.",
+};
+
+const FILE_READ_FAILED: ImportFileError = {
+  code: "file-read-failed",
+  message: "Spectre could not read this file. Choose a readable local config file and try again.",
+};
+
+export function validateImportSourceText(source: string): ImportFileError | null {
+  // Line totals count content lines: a trailing newline terminates the last
+  // line instead of starting a new one, so "a\n" is 1 line, not 2. The
+  // in-loop limit allows one extra line to avoid rejecting an exactly
+  // 10,000-line newline-terminated file before the trailing-newline
+  // adjustment below can apply.
+  let lineCount = source.length === 0 ? 0 : 1;
+  let lineLength = 0;
+
+  for (const character of source) {
+    if (character === "\0") {
+      return {
+        code: "likely-binary",
+        message: "This file contains a NUL byte and appears to be binary.",
+      };
+    }
+
+    if (character === "\n") {
+      lineCount += 1;
+      if (lineCount > IMPORT_FILE_LIMITS.maxLines + 1) {
+        return {
+          code: "too-many-lines",
+          message: `Config files may contain at most ${IMPORT_FILE_LIMITS.maxLines.toLocaleString()} lines.`,
+        };
+      }
+      lineLength = 0;
+      continue;
+    }
+
+    lineLength += 1;
+    if (lineLength > IMPORT_FILE_LIMITS.maxLineLength) {
+      return {
+        code: "line-too-long",
+        message: `Each config line must be at most ${IMPORT_FILE_LIMITS.maxLineLength.toLocaleString()} characters.`,
+      };
+    }
+  }
+
+  if (source.endsWith("\n")) {
+    lineCount -= 1;
+  }
+  if (lineCount > IMPORT_FILE_LIMITS.maxLines) {
+    return {
+      code: "too-many-lines",
+      message: `Config files may contain at most ${IMPORT_FILE_LIMITS.maxLines.toLocaleString()} lines.`,
+    };
+  }
+
+  return null;
+}
+
+export async function analyzeImportFile(
+  file: ImportFileLike,
+  isCurrent: () => boolean = () => true
+): Promise<ImportFileAnalysisResult> {
+  if (file.size > IMPORT_FILE_LIMITS.maxBytes) {
+    return { status: "error", error: FILE_TOO_LARGE };
+  }
+
+  let source: string;
+  try {
+    source = await file.text();
+  } catch {
+    return isCurrent()
+      ? { status: "error", error: FILE_READ_FAILED }
+      : { status: "stale" };
+  }
+
+  // Check immediately after the only asynchronous boundary, before scanning or
+  // analyzing source that has already been superseded by a newer selection.
+  if (!isCurrent()) return { status: "stale" };
+
+  const sourceError = validateImportSourceText(source);
+  if (sourceError) return { status: "error", error: sourceError };
+
+  // analyzeGhosttyConfig is pure and linear over bounded input, so this
+  // should never throw. Guard the fire-and-forget coordinator path anyway so
+  // an unexpected failure surfaces as a local error instead of an unhandled
+  // rejection with the UI stuck in loading state.
+  try {
+    return {
+      status: "success",
+      fileName: file.name,
+      fileSize: file.size,
+      analysis: analyzeGhosttyConfig(source),
+    };
+  } catch {
+    return { status: "error", error: FILE_READ_FAILED };
+  }
+}


### PR DESCRIPTION
Closes #71.

Local file boundary (1 MiB, 10k lines, 64k chars, NUL) plus a token coordinator so stale reads can't publish the wrong review or error. Extensionless config files keep working.

Validation: lint, typecheck, 428 unit tests, build, schema check, 17/17 Playwright tests.