### PR TITLE
feat(import): complete accessibility, mobile, and rollout coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Prevented the editor's mobile category strip from widening the page beyond the viewport.
 - Preserved Ghostty's extensionless `config` filename when downloading from editor and shared-config views.
 - Rejected invalid imported booleans, numbers, enums, colors, and durations with line-level diagnostics instead of silently coercing them.
+- Gave import-review error diagnostics a contrast-safe red so they meet WCAG AA on dialog surfaces in both themes.
+- Kept the editor header within the viewport on 320-pixel screens and made long imported values wrap inside the review dialog instead of overflowing it.
 
 ## [0.3.0] - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ bun run build
 bun run start
 ```
 
+### Importing an existing Ghostty config
+
+Use the Import button in the editor header to bring in a `config` file. Imports are
+**review-before-replace**: Spectre analyzes the file locally, shows every effective
+instruction with line-level diagnostics, and only replaces your current settings when
+you confirm with an explicit action such as `Replace with 10 settings and skip 2 lines`.
+
+- Valid settings can be partially imported while invalid lines are skipped with
+  actionable messages — invalid values are never silently coerced.
+- Options Spectre does not recognize are retained as visibly **Unverified** strings
+  (last value wins); unsafe option names are rejected.
+- Files are checked locally before parsing: at most 1 MiB, 10,000 lines, 65,536
+  characters per line, and no binary (NUL-byte) content.
+- `config-file` include directives are listed but never followed — counts cover only
+  the selected file, not Ghostty's final effective configuration.
+
 ## Tech Stack
 
 - **Framework**: [Next.js 16](https://nextjs.org/) (App Router)

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -99,6 +99,96 @@ test("the theme browser has no automatically detectable WCAG A or AA violations"
   expect(await findAccessibilityViolations(page)).toEqual([]);
 });
 
+async function openImportReview(page: Page, buffer: Buffer) {
+  await page.goto("/editor");
+  await expect(page.getByRole("heading", { name: "Fonts" })).toBeVisible();
+
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import Config" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "config",
+    mimeType: "text/plain",
+    buffer,
+  });
+  await expect(
+    page.getByRole("heading", { name: "Review imported configuration" })
+  ).toBeVisible();
+}
+
+test("the valid-only import review has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await openImportReview(
+    page,
+    Buffer.from("font-size = 18\ncursor-style = bar\n")
+  );
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the import review with warnings has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await openImportReview(
+    page,
+    Buffer.from("font-size = 14\nfont-size = 16\nfuture-option = abc\n")
+  );
+
+  await expect(page.getByText("Unverified", { exact: true })).toBeVisible();
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the import review with errors has no automatically detectable WCAG A or AA violations", async ({
+  page,
+}) => {
+  await openImportReview(
+    page,
+    Buffer.from(
+      "font-size = 16\nmouse-hide-while-typing = maybe\nnot an instruction\n"
+    )
+  );
+
+  await expect(
+    page.getByRole("button", {
+      name: "Replace with 1 setting and skip 2 lines",
+    })
+  ).toBeVisible();
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("the mobile import review remains usable without horizontal overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 844 });
+  await openImportReview(
+    page,
+    Buffer.from(
+      [
+        "font-family = First Family With A Long Name",
+        "font-family = Second Family With A Long Name",
+        "keybind = ctrl+shift+c=copy_to_clipboard",
+        "palette = 0=#ffffff",
+        `future-option = ${"x".repeat(200)}`,
+        "mouse-hide-while-typing = maybe",
+      ].join("\n") + "\n"
+    )
+  );
+
+  await expect(page.getByRole("button", { name: "Cancel" })).toBeFocused();
+  await page.keyboard.press("Tab");
+  const focusStaysInDialog = await page.evaluate(() =>
+    Boolean(document.activeElement?.closest('[data-slot="dialog-content"]'))
+  );
+  expect(focusStaysInDialog).toBe(true);
+
+  const hasHorizontalPageOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth
+  );
+  expect(hasHorizontalPageOverflow).toBe(false);
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
 test("the mobile theme browser supports keyboard navigation without horizontal overflow", async ({
   page,
 }) => {

--- a/e2e/critical-workflows.spec.ts
+++ b/e2e/critical-workflows.spec.ts
@@ -428,6 +428,50 @@ test("a user can recover from a rejected config file without reloading", async (
   await expect(fontSize).toHaveValue("18");
 });
 
+test("a user can dismiss the import review by keyboard or overlay without losing state", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  const fontSize = page.locator('#option-font-size input[type="number"]');
+  await fontSize.fill("16");
+
+  const importButton = page.getByRole("button", { name: "Import Config" });
+  const reviewHeading = page.getByRole("heading", {
+    name: "Review imported configuration",
+  });
+  const reviewFile = {
+    name: "config",
+    mimeType: "text/plain",
+    buffer: Buffer.from("font-size = 18\n"),
+  };
+
+  // Escape dismisses, preserves state, and returns focus to the trigger.
+  let fileChooserPromise = page.waitForEvent("filechooser");
+  await importButton.click();
+  let fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(reviewFile);
+  await expect(reviewHeading).toBeVisible();
+  await expect(page.getByRole("button", { name: "Cancel" })).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(reviewHeading).not.toBeVisible();
+  await expect(importButton).toBeFocused();
+  await expect(fontSize).toHaveValue("16");
+
+  // Overlay dismissal behaves the same.
+  fileChooserPromise = page.waitForEvent("filechooser");
+  await importButton.click();
+  fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(reviewFile);
+  await expect(reviewHeading).toBeVisible();
+  await page
+    .locator('[data-slot="dialog-overlay"]')
+    .click({ position: { x: 5, y: 5 } });
+  await expect(reviewHeading).not.toBeVisible();
+  await expect(importButton).toBeFocused();
+  await expect(fontSize).toHaveValue("16");
+});
+
 test("a user can navigate and inspect configuration on a mobile screen", async ({
   page,
 }) => {

--- a/src/components/editor/ImportReviewDialog.tsx
+++ b/src/components/editor/ImportReviewDialog.tsx
@@ -151,7 +151,7 @@ export function ImportReviewDialog({
               aria-label="Imported instructions"
             >
               {effectiveInstructions.map((instruction) => (
-                <li key={`${instruction.lineNumber}-${instruction.key}`} className="break-words">
+                <li key={`${instruction.lineNumber}-${instruction.key}`} className="wrap-anywhere">
                   <span className="mr-2 text-muted-foreground">
                     Line {instruction.lineNumber}
                   </span>{" "}
@@ -225,8 +225,11 @@ export function ImportReviewDialog({
                     key={`${diagnostic.lineNumber}-${diagnostic.code}`}
                     className={
                       diagnostic.severity === "error"
-                        ? "break-words text-destructive"
-                        : "break-words text-amber-600 dark:text-amber-400"
+                        // Contrast-safe error red: the global --destructive token
+                        // fails WCAG AA on dialog surfaces (see follow-up to audit
+                        // it for all text uses).
+                        ? "wrap-anywhere text-red-700 dark:text-red-300"
+                        : "wrap-anywhere text-amber-600 dark:text-amber-400"
                     }
                   >
                     {`${formatDiagnosticSeverity(diagnostic)} — Line ${diagnostic.lineNumber}`}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -311,11 +311,11 @@ export function Header() {
             </Tooltip>
           </TooltipProvider>
 
-          {/* GitHub */}
+          {/* GitHub - hidden on very small screens to keep the header within 320px */}
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" asChild className="h-9 w-9">
+                <Button variant="ghost" size="icon" asChild className="hidden h-9 w-9 sm:inline-flex">
                   <a
                     href="https://github.com/imrajyavardhan12/spectre-ghostty-config"
                     target="_blank"


### PR DESCRIPTION
Closes #72. With #67-#71 merged, this completes the import-diagnostics epic #65.

Coverage: Escape/overlay dismissal with focus return and state preservation, Axe with the review open in valid/warning/error states, 320px mobile review without overflow, and user-facing import docs in README plus changelog.

Fixes found by the new tests: contrast-safe error red in the review dialog, header kept within 320px viewports, long imported values wrap inside the dialog.

Validation: lint, typecheck, 428 unit tests, build, 22/22 Playwright tests.

Note: manual screen-reader sign-off was not possible here; automated cover stands in via keyboard-only dismissal/focus/trap paths and Axe in all three dialog states. Follow-up issues to be filed: global --destructive token audit, eslint ignores for test-output dirs, light-mode Axe coverage.