### PR TITLE
chore(lint): ignore generated test-output dirs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
     "next-env.d.ts",
   ]),
 ]);


### PR DESCRIPTION
Closes #82.

Adds playwright-report/ and test-results/ to the eslint flat-config ignores (both were already gitignored). Previously any failing e2e run broke the next local lint with errors in generated trace assets; CI order masked it.

Verified: planted type-error fixtures in both dirs, lint passes; removed them, lint passes.

Validation: lint, typecheck.