### PR TITLE
feat(a11y): retune destructive token and name icon-only controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 - Rejected invalid imported booleans, numbers, enums, colors, and durations with line-level diagnostics instead of silently coercing them.
 - Gave import-review error diagnostics a contrast-safe red so they meet WCAG AA on dialog surfaces in both themes.
 - Kept the editor header within the viewport on 320-pixel screens and made long imported values wrap inside the review dialog instead of overflowing it.
+- Retuned the `--destructive` token in both themes so error text meets WCAG AA contrast, and gave the color-swatch picker, empty select triggers, and keybind add/remove/help/action controls accessible names.
+- Used inverted severity colors for keybind errors and warnings shown inside tooltips, whose surfaces invert with the theme.
 
 ## [0.3.0] - 2026-07-03
 

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -189,6 +189,73 @@ test("the mobile import review remains usable without horizontal overflow", asyn
   expect(await findAccessibilityViolations(page)).toEqual([]);
 });
 
+test("editor field errors meet WCAG contrast", async ({ page }) => {
+  await page.goto("/editor");
+  await page.getByRole("button", { name: "Colors", exact: true }).click();
+  await page.locator("#option-background input").fill("notacolor");
+  await expect(
+    page.locator("#option-background").getByRole("alert")
+  ).toContainText("Use #RGB");
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("keybind row errors meet WCAG contrast", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "spectre-config",
+      JSON.stringify({
+        state: {
+          config: {
+            keybind: ["ctrl+ctrl+c=new_tab", "ctrl+k=close_all_windows"],
+          },
+          appliedTheme: null,
+        },
+        version: 0,
+      })
+    );
+  });
+  await page.goto("/editor");
+  await page.getByRole("button", { name: /Keybinds/ }).click();
+  await expect(
+    page.locator("#option-keybind").getByText("ctrl+ctrl+c")
+  ).toBeVisible();
+
+  const rowErrorIcon = page.locator('#option-keybind svg.text-destructive').first();
+  await expect(rowErrorIcon).toBeVisible();
+  await rowErrorIcon.hover();
+  await expect(page.getByText("Duplicate modifier").first()).toBeAttached();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+
+  const rowWarningIcon = page.locator('#option-keybind svg.text-amber-500').first();
+  await expect(rowWarningIcon).toBeVisible();
+  await rowWarningIcon.hover();
+  await expect(page.getByText(/is deprecated/).first()).toBeAttached();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
+test("theme download errors meet WCAG contrast", async ({ page }) => {
+  const draculaUrl =
+    "https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/ghostty/Dracula";
+  await page.route(THEME_LIST_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ type: "file", name: "Dracula", download_url: draculaUrl }]),
+    })
+  );
+  await page.route(draculaUrl, (route) =>
+    route.fulfill({ status: 500, contentType: "text/plain", body: "error" })
+  );
+
+  await page.goto("/themes");
+  await expect(page.getByText("1 theme failed to load.")).toBeVisible();
+
+  expect(await findAccessibilityViolations(page)).toEqual([]);
+});
+
 test("the mobile theme browser supports keyboard navigation without horizontal overflow", async ({
   page,
 }) => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,7 +70,7 @@
   --muted-foreground: #6b6b6b;
   --accent: #e8ede9;
   --accent-foreground: #3d5347;
-  --destructive: #c45c5c;
+  --destructive: #b91c1c;
   --border: #e5e7e5;
   --input: #e5e7e5;
   --ring: #5c7c6e;
@@ -112,7 +112,7 @@
   --muted-foreground: #9e9e9e;
   --accent: #1e2620;
   --accent-foreground: #a8c4b4;
-  --destructive: #c45c5c;
+  --destructive: #fca5a5;
   --border: #333333;
   --input: #333333;
   --ring: #8faa9d;

--- a/src/components/editor/ImportReviewDialog.tsx
+++ b/src/components/editor/ImportReviewDialog.tsx
@@ -225,10 +225,7 @@ export function ImportReviewDialog({
                     key={`${diagnostic.lineNumber}-${diagnostic.code}`}
                     className={
                       diagnostic.severity === "error"
-                        // Contrast-safe error red: the global --destructive token
-                        // fails WCAG AA on dialog surfaces (see follow-up to audit
-                        // it for all text uses).
-                        ? "wrap-anywhere text-red-700 dark:text-red-300"
+                        ? "wrap-anywhere text-destructive"
                         : "wrap-anywhere text-amber-600 dark:text-amber-400"
                     }
                   >

--- a/src/components/settings/ActionCombobox.tsx
+++ b/src/components/settings/ActionCombobox.tsx
@@ -164,6 +164,7 @@ export function ActionCombobox({
                     variant="outline"
                     role="combobox"
                     aria-expanded={open}
+                    aria-label="Select keybind action"
                     className={cn(
                         "justify-between font-mono text-sm h-9",
                         !value && "text-muted-foreground",

--- a/src/components/settings/ColorInput.tsx
+++ b/src/components/settings/ColorInput.tsx
@@ -73,6 +73,7 @@ export function ColorInput({ option }: ColorInputProps) {
             <Button
               variant="outline"
               className="h-10 w-14 p-1"
+              aria-label={`Choose ${option.name} color`}
               style={{
                 backgroundColor: isDisplayableColor ? hexColor! : "transparent",
               }}

--- a/src/components/settings/KeybindInput.tsx
+++ b/src/components/settings/KeybindInput.tsx
@@ -158,11 +158,13 @@ export function KeybindInput({ option }: KeybindInputProps) {
                         </TooltipTrigger>
                         <TooltipContent side="left" className="max-w-xs">
                           <div className="space-y-1">
+                            {/* Tooltip surfaces are inverted (light bg in dark theme), so severity
+                                colors use the opposite pairing from normal surfaces. */}
                             {validation.errors.map((err, i) => (
-                              <p key={i} className="text-xs text-destructive">{err}</p>
+                              <p key={i} className="text-xs text-red-300 dark:text-red-700">{err}</p>
                             ))}
                             {validation.warnings.map((warn, i) => (
-                              <p key={i} className="text-xs text-amber-500">{warn}</p>
+                              <p key={i} className="text-xs text-amber-300 dark:text-amber-800">{warn}</p>
                             ))}
                           </div>
                         </TooltipContent>
@@ -175,6 +177,7 @@ export function KeybindInput({ option }: KeybindInputProps) {
                     size="icon"
                     className="h-6 w-6 shrink-0"
                     onClick={() => removeKeybind(index)}
+                    aria-label={`Remove keybind ${keybind}`}
                   >
                     <X className="h-4 w-4" />
                   </Button>
@@ -254,6 +257,7 @@ export function KeybindInput({ option }: KeybindInputProps) {
               size="icon"
               onClick={addKeybind}
               disabled={!canAdd}
+              aria-label="Add keybind"
             >
               <Plus className="h-4 w-4" />
             </Button>
@@ -261,7 +265,7 @@ export function KeybindInput({ option }: KeybindInputProps) {
             {/* Help / Examples button */}
             <Popover open={showExamples} onOpenChange={setShowExamples}>
               <PopoverTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-9 w-9">
+                <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="Show keybind examples">
                   <HelpCircle className="h-4 w-4 text-muted-foreground" />
                 </Button>
               </PopoverTrigger>

--- a/src/components/settings/SelectInput.tsx
+++ b/src/components/settings/SelectInput.tsx
@@ -48,7 +48,7 @@ export function SelectInput({ option }: SelectInputProps) {
         value={toUiValue(value ?? option.default)}
         onValueChange={(v) => setValue(option.id, fromUiValue(v))}
       >
-        <SelectTrigger className="max-w-xs">
+        <SelectTrigger className="max-w-xs" aria-label={option.name}>
           <SelectValue placeholder="Select an option" />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
Closes #81.

Retunes --destructive per theme so error text meets WCAG AA (verified: no white-text-on-destructive surfaces render anywhere, only secondary/outline button and badge variants are used). Reverts the #80 dialog one-off back to the token. Names the color-swatch, empty select, and keybind add/remove/help/action controls. Keybind tooltip severity colors use the inverted pairing its inverted surface requires (amber-800, caught by the new warning seed).

Validation: lint, typecheck, 428 unit tests, build, 25/25 Playwright tests including new contrast coverage for editor, keybind error and warning, and theme-download error states.