### PR TITLE
feat(version): target version state and support helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Ghostty configuration changes should be traceable to the official Ghostty docs o
 
 ### Added
 
+- Added a Ghostty target-version selector to the editor sidebar, persisted across reloads, so filtering and warnings can follow the release installed where a config will run.
 - Added Playwright browser tests for the landing-to-editor path, import/export, config sharing, mobile navigation, preview recovery, theme-service recovery, and automated WCAG A/AA checks.
 - Added focused unit coverage for theme loading concurrency, prioritization, and cancellation.
 - Added focused unit coverage for Ghostty preview lifecycle and supersession races.

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,6 +22,14 @@ import {
 import { Category } from "@/lib/schema/types";
 import { useConfigStore } from "@/lib/store/config-store";
 import { getOptionsByCategory } from "@/data/ghostty-options";
+import { GHOSTTY_RELEASES } from "@/lib/ghostty-versions";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Type,
@@ -46,6 +54,8 @@ interface SidebarProps {
 
 export function Sidebar({ activeCategory, onCategoryChange }: SidebarProps) {
   const config = useConfigStore((state) => state.config);
+  const targetVersion = useConfigStore((state) => state.targetVersion);
+  const setTargetVersion = useConfigStore((state) => state.setTargetVersion);
 
   const getModifiedCount = (categoryId: Category): number => {
     const options = getOptionsByCategory(categoryId);
@@ -56,6 +66,23 @@ export function Sidebar({ activeCategory, onCategoryChange }: SidebarProps) {
     <aside className="w-60 border-r border-border bg-background hidden md:flex flex-col">
       <ScrollArea className="flex-1">
         <div className="p-3 space-y-1">
+          <div className="px-3 py-2">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Ghostty version
+            </p>
+            <Select value={targetVersion} onValueChange={setTargetVersion}>
+              <SelectTrigger aria-label="Ghostty target version" className="mt-1.5 h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {GHOSTTY_RELEASES.map((release) => (
+                  <SelectItem key={release} value={release} className="text-xs">
+                    {release}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <p className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
             Categories
           </p>

--- a/src/lib/ghostty-versions.test.ts
+++ b/src/lib/ghostty-versions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  GHOSTTY_BASELINE_VERSION,
+  GHOSTTY_RELEASES,
+  compareGhosttyVersions,
+  getOptionIntroducedIn,
+  isKnownGhosttyRelease,
+  isOptionSupportedIn,
+} from "@/lib/ghostty-versions";
+
+describe("ghostty versions", () => {
+  it("pins the audited stable release list", () => {
+    expect(GHOSTTY_RELEASES).toEqual([
+      "1.0.0", "1.0.1",
+      "1.1.0", "1.1.1", "1.1.2", "1.1.3",
+      "1.2.0", "1.2.1", "1.2.2", "1.2.3",
+      "1.3.0", "1.3.1",
+    ]);
+    expect(GHOSTTY_BASELINE_VERSION).toBe("1.0.0");
+  });
+
+  it("compares versions numerically across granularities", () => {
+    expect(compareGhosttyVersions("1.3.1", "1.3.1")).toBe(0);
+    expect(compareGhosttyVersions("1.2.0", "1.10.0")).toBeLessThan(0);
+    expect(compareGhosttyVersions("1.2.3", "1.2.0")).toBeGreaterThan(0);
+    expect(compareGhosttyVersions("1.3.0", "1.2.3")).toBeGreaterThan(0);
+    expect(compareGhosttyVersions("1.0.1", "1.0.0")).toBeGreaterThan(0);
+  });
+
+  it("recognizes only listed releases", () => {
+    expect(isKnownGhosttyRelease("1.3.1")).toBe(true);
+    expect(isKnownGhosttyRelease("1.0.0")).toBe(true);
+    expect(isKnownGhosttyRelease("1.4.0")).toBe(false);
+    expect(isKnownGhosttyRelease("tip")).toBe(false);
+    expect(isKnownGhosttyRelease("")).toBe(false);
+  });
+
+  it("resolves introduction from audited metadata with a 1.0 baseline", () => {
+    expect(getOptionIntroducedIn("font-size")).toBe("1.0.0");
+    expect(getOptionIntroducedIn("link")).toBe("1.0.0");
+    expect(getOptionIntroducedIn("progress-style")).toBe("1.3.1");
+    expect(getOptionIntroducedIn("scroll-to-bottom")).toBe("1.2.0");
+  });
+
+  it("supports same-or-older options and treats unknown ids as supported", () => {
+    expect(isOptionSupportedIn("progress-style", "1.3.1")).toBe(true);
+    expect(isOptionSupportedIn("progress-style", "1.3.0")).toBe(false);
+    expect(isOptionSupportedIn("font-size", "1.0.0")).toBe(true);
+    expect(isOptionSupportedIn("window-titlebar-background", "1.0.0")).toBe(false);
+    expect(isOptionSupportedIn("window-titlebar-background", "1.0.1")).toBe(true);
+    expect(isOptionSupportedIn("future-option", "1.0.0")).toBe(true);
+  });
+});

--- a/src/lib/ghostty-versions.ts
+++ b/src/lib/ghostty-versions.ts
@@ -1,0 +1,57 @@
+import { getConfigOption } from "@/lib/utils/config-options";
+
+/** Baseline Ghostty release: options without sinceVersion metadata date to 1.0. */
+export const GHOSTTY_BASELINE_VERSION = "1.0.0";
+
+/**
+ * Ghostty stable releases that may appear as option availability or as the
+ * editor target version. Source-audited in scripts/audit-ghostty-version-availability.ts.
+ * When Ghostty ships a new stable release, append it here.
+ */
+export const GHOSTTY_RELEASES = [
+  "1.0.0",
+  "1.0.1",
+  "1.1.0",
+  "1.1.1",
+  "1.1.2",
+  "1.1.3",
+  "1.2.0",
+  "1.2.1",
+  "1.2.2",
+  "1.2.3",
+  "1.3.0",
+  "1.3.1",
+] as const;
+
+export type GhosttyRelease = (typeof GHOSTTY_RELEASES)[number];
+
+export function isKnownGhosttyRelease(version: string): version is GhosttyRelease {
+  return (GHOSTTY_RELEASES as readonly string[]).includes(version);
+}
+
+/** Numeric major.minor.patch comparison: negative when a < b, positive when a > b. */
+export function compareGhosttyVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/** Release that introduced the option; absent metadata means the 1.0 baseline. */
+export function getOptionIntroducedIn(optionId: string): string {
+  return getConfigOption(optionId)?.sinceVersion ?? GHOSTTY_BASELINE_VERSION;
+}
+
+/**
+ * Whether the option exists in the given Ghostty target version.
+ * Unknown option IDs are treated as supported: absence from the schema is a
+ * forward-compatibility question, not a version question.
+ *
+ * @param targetVersion must be a known release (see isKnownGhosttyRelease);
+ *   anything else degrades to unsupported for every option.
+ */
+export function isOptionSupportedIn(optionId: string, targetVersion: string): boolean {
+  return compareGhosttyVersions(targetVersion, getOptionIntroducedIn(optionId)) >= 0;
+}

--- a/src/lib/store/config-store.test.ts
+++ b/src/lib/store/config-store.test.ts
@@ -689,6 +689,71 @@ unknown-option = true
       expect(diff).toEqual({ 'font-size': 16 });
     });
   });
+
+  describe('targetVersion', () => {
+    it('should default to the compatibility stable version', () => {
+      expect(getStoreState().targetVersion).toBe(GHOSTTY_COMPATIBILITY_VERSION);
+    });
+
+    it('should accept known releases and ignore anything else', () => {
+      act(() => {
+        useConfigStore.getState().setTargetVersion('1.1.0');
+      });
+      expect(getStoreState().targetVersion).toBe('1.1.0');
+
+      act(() => {
+        useConfigStore.getState().setTargetVersion('9.9.9');
+      });
+      expect(getStoreState().targetVersion).toBe('1.1.0');
+
+      act(() => {
+        useConfigStore.getState().setTargetVersion(GHOSTTY_COMPATIBILITY_VERSION);
+      });
+    });
+
+    it('should survive config edits, imports, and resets untouched', () => {
+      act(() => {
+        useConfigStore.getState().setTargetVersion('1.2.0');
+      });
+      act(() => {
+        useConfigStore.getState().setValue('font-size', 16);
+      });
+      expect(getStoreState().targetVersion).toBe('1.2.0');
+
+      applyConfigImport('font-size = 18\n');
+      expect(getStoreState().targetVersion).toBe('1.2.0');
+
+      act(() => {
+        useConfigStore.getState().resetAll();
+      });
+      expect(getStoreState().targetVersion).toBe('1.2.0');
+      expect(getStoreState().config).toEqual({});
+
+      act(() => {
+        useConfigStore.getState().setTargetVersion(GHOSTTY_COMPATIBILITY_VERSION);
+      });
+    });
+
+    it('should coerce invalid or missing persisted target versions to default on merge', () => {
+      const merge = useConfigStore.persist.getOptions().merge!;
+      const current = getStoreState();
+
+      const valid = merge(
+        { config: {}, appliedTheme: null, targetVersion: '1.2.0' },
+        current
+      );
+      expect(valid.targetVersion).toBe('1.2.0');
+
+      const invalid = merge(
+        { config: {}, appliedTheme: null, targetVersion: '9.9.9' },
+        current
+      );
+      expect(invalid.targetVersion).toBe(GHOSTTY_COMPATIBILITY_VERSION);
+
+      const missing = merge({ config: {}, appliedTheme: null }, current);
+      expect(missing.targetVersion).toBe(GHOSTTY_COMPATIBILITY_VERSION);
+    });
+  });
 });
 
 // Helper to avoid repeating getStoreState

--- a/src/lib/store/config-store.ts
+++ b/src/lib/store/config-store.ts
@@ -9,6 +9,8 @@ import {
   normalizeConfigValues,
 } from "@/lib/utils/config-normalization";
 import { isThemeConfigKey } from "@/lib/utils/theme-config";
+import { GHOSTTY_COMPATIBILITY_VERSION } from "@/lib/compatibility";
+import { isKnownGhosttyRelease } from "@/lib/ghostty-versions";
 
 export type { ConfigValues };
 
@@ -19,6 +21,10 @@ interface ConfigStore {
   // Current applied theme name (for export comment)
   appliedTheme: string | null;
 
+  // Ghostty release the config targets (editor filtering, export/share warnings).
+  // A view preference: never modified by config edits, imports, or resets.
+  targetVersion: string;
+
   // Actions
   setValue: (key: string, value: unknown) => void;
   resetValue: (key: string) => void;
@@ -26,6 +32,7 @@ interface ConfigStore {
   applyImportedCandidate: (config: ConfigValues) => void;
   loadConfig: (config: ConfigValues, themeName?: string) => void;
   setAppliedTheme: (themeName: string | null) => void;
+  setTargetVersion: (version: string) => void;
 
   // Computed helpers
   getValue: (key: string) => unknown;
@@ -40,6 +47,7 @@ export const useConfigStore = create<ConfigStore>()(
     (set, get) => ({
       config: createConfigValues(),
       appliedTheme: null,
+      targetVersion: GHOSTTY_COMPATIBILITY_VERSION,
 
       setValue: (key: string, value: unknown) => {
         set((state) => {
@@ -74,6 +82,11 @@ export const useConfigStore = create<ConfigStore>()(
         set({ appliedTheme: themeName });
       },
 
+      setTargetVersion: (version: string) => {
+        if (!isKnownGhosttyRelease(version)) return;
+        set({ targetVersion: version });
+      },
+
       getValue: (key: string) => {
         const { config } = get();
         if (key in config) {
@@ -106,10 +119,10 @@ export const useConfigStore = create<ConfigStore>()(
     }),
     {
       name: "spectre-config",
-      partialize: (state) => ({ config: state.config, appliedTheme: state.appliedTheme }),
+      partialize: (state) => ({ config: state.config, appliedTheme: state.appliedTheme, targetVersion: state.targetVersion }),
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<
-          Pick<ConfigStore, "config" | "appliedTheme">
+          Pick<ConfigStore, "config" | "appliedTheme" | "targetVersion">
         >;
         const config = persisted.config &&
           typeof persisted.config === "object" &&
@@ -119,8 +132,12 @@ export const useConfigStore = create<ConfigStore>()(
         const appliedTheme = typeof persisted.appliedTheme === "string"
           ? persisted.appliedTheme
           : null;
+        const targetVersion = typeof persisted.targetVersion === "string" &&
+          isKnownGhosttyRelease(persisted.targetVersion)
+          ? persisted.targetVersion
+          : GHOSTTY_COMPATIBILITY_VERSION;
 
-        return { ...currentState, config, appliedTheme };
+        return { ...currentState, config, appliedTheme, targetVersion };
       },
       skipHydration: true,
     }


### PR DESCRIPTION
Closes #87 (slice A of #86).

Persisted Ghostty target version (default: compatibility stable), semver support helper over audited metadata, sidebar selector, unit coverage including persist-merge coercion. No behavior change with the default target; mobile selector rides with #88.

Validation: lint, typecheck, 439 unit tests, build, 25/25 Playwright tests.